### PR TITLE
comment eol after environment

### DIFF
--- a/test-luamplib-latex.tex
+++ b/test-luamplib-latex.tex
@@ -18,7 +18,7 @@ A%
 beginfig(1);
 	fill fullcircle scaled 20; %% actual <tab> to make sure it works
 endfig;
-\end{mplibcode}
+\end{mplibcode}%
 B\par
 \begin{mplibcode}
 beginfig(18);


### PR DESCRIPTION
I’m not sure as to how LaTeX environments are supposed to work, but from my perspective the behavior is acceptable and the test was incorrect. To suppress the space, escape the endline character -- that’s TeX.
