### PR TITLE
v2.11.0

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,8 @@
                        History of the luamplib package
 
-2015/06/03 2.10.2
+2015/06/09 2.10.2
+    * allow access to type1 fonts, which means we can use glyph
+      operator now (rev 5266)
     * transparency is now compatible with pgf package, including
       beamer class. Upon plain TeX, tikz should be loaded before
       luamplib package.

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,6 @@
                        History of the luamplib package
 
-2015/06/09 2.10.2
+2015/06/27 2.10.2
     * allow access to type1 fonts, which means we can use glyph
       operator now (rev 5266)
     * transparency is now compatible with pgf package, including

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,10 @@
                        History of the luamplib package
 
+2015/05/04 2.10.2
+    * transparency is now compatible with pgf package, including
+      beamer class. Upon plain TeX, tikz should be loaded before
+      luamplib package.
+
 2015/03/26 2.10.1
     * fix bug #55 regarding hash token
 

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,6 @@
                        History of the luamplib package
 
-2015/05/04 2.10.2
+2015/06/03 2.10.2
     * transparency is now compatible with pgf package, including
       beamer class. Upon plain TeX, tikz should be loaded before
       luamplib package.

--- a/NEWS
+++ b/NEWS
@@ -1,10 +1,14 @@
                        History of the luamplib package
 
-2015/06/27 2.10.2
+2015/08/01 2.11.0
+    * after `\mplibverbatim{enable}', contents of mplibcode environment
+      will be read verbatim. So `btex ... etex', `verbatimtex ... etex',
+      `\mpdim', `\mpcolor' are not allowed and all TeX commands will be
+      fed literally into mplib library.
     * allow access to type1 fonts, which means we can use glyph
-      operator now (rev 5266)
-    * transparency is now compatible with pgf package, including
-      beamer class. (LuaTeX 0.80+ is recommended)
+      operator now (luatex rev 5266)
+    * color transparency is now compatible with pgf package and
+      beamer class as well. (luatex 0.80+ is recommended)
 
 2015/03/26 2.10.1
     * fix bug #55 regarding hash token

--- a/NEWS
+++ b/NEWS
@@ -4,8 +4,7 @@
     * allow access to type1 fonts, which means we can use glyph
       operator now (rev 5266)
     * transparency is now compatible with pgf package, including
-      beamer class. Upon plain TeX, tikz should be loaded before
-      luamplib package.
+      beamer class. (LuaTeX 0.80+ is recommended)
 
 2015/03/26 2.10.1
     * fix bug #55 regarding hash token

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -1266,7 +1266,7 @@ local function update_tr_res(res,mode,opaq)
       res = format("%s/MPlibTr%i %i 0 R",res,on,on)
     else
       if luamplib.pgf_loaded then
-        texsprint(format("\\special{pdf:put @pgfextgs<</MPlibTr%i%s>>}",on,os))
+        texsprint(format("\\csname pgf@sys@addpdfresource@extgs@plain\\endcsname{/MPlibTr%i%s}",on,os))
       else
         texsprint(format("\\special{pdf:put @MPlibTr<</MPlibTr%i%s>>}",on,os))
       end
@@ -1281,12 +1281,14 @@ local function tr_pdf_pageresources(mode,opaq)
   res, on_on  = update_tr_res(res, mode, opaq)
   if pdfmode then
     if res ~= "" then
-      if luamplib.pgf_loaded then
-        local res_toks = texgettoks("pgf@sys@pgf@resource@list@extgs@toks")
-        texsettoks("global", "pgf@sys@pgf@resource@list@extgs@toks", res_toks..res)
+      local tpr = texget("pdfpageresources") -- respect luaotfload-colors
+      local no_extgs = not stringfind(tpr,"/ExtGState<<.*>>")
+      local pgf_loaded = no_extgs and (luaotfload and luaotfload.pgf_loaded or luamplib.pgf_loaded)
+      if pgf_loaded and type(pgf_loaded) == "number" then
+        local res_toks = texgettoks(pgf_loaded)
+        texsettoks("global", pgf_loaded, res_toks..res)
       else
-        local tpr = texget("pdfpageresources") -- respect luaotfload-colors
-        if not stringfind(tpr,"/ExtGState<<.*>>") then
+        if no_extgs then
           tpr = tpr.."/ExtGState<<>>"
         end
         tpr = stringgsub(tpr,"/ExtGState<<","%1"..res)
@@ -1964,6 +1966,7 @@ luamplib.colorconverter = colorconverter
     \ifcase\pdfoutput\else
       \@ifpackageloaded{luaotfload}{}{
         \csname newtoks\endcsname\pgf@sys@pgf@resource@list@extgs@toks
+        \directlua{luamplib.pgf_loaded=\the\allocationnumber}
         \def\pgf@sys@pgf@resource@list@extgs{\the\pgf@sys@pgf@resource@list@extgs@toks}
         \def\pgf@sys@addpdfresource@extgs@plain#1{\global\pgf@sys@pgf@resource@list@extgs@toks
           \expandafter{\the\pgf@sys@pgf@resource@list@extgs@toks #1}}}
@@ -1975,7 +1978,7 @@ luamplib.colorconverter = colorconverter
 %    for plain tex, pgf loaded.
 %    \begin{macrocode}
 \directlua{luamplib.pgf_loaded=true}
-\ifcsname pgf@sys@pgf@resource@list@extgs\endcsname\else\endinput\fi
+\ifcase\pdfoutput\endinput\fi
 %    \end{macrocode}
 %    pgfsys-pdftex.def loaded. Not dvi mode
 %    \begin{macrocode}
@@ -1986,6 +1989,7 @@ luamplib.colorconverter = colorconverter
 \count255=\the\catcode`@\relax
 \catcode`@=11\relax
 \newtoks\pgf@sys@pgf@resource@list@extgs@toks
+\directlua{luamplib.pgf_loaded=\the\allocationnumber}
 \def\pgf@sys@pgf@resource@list@extgs{\the\pgf@sys@pgf@resource@list@extgs@toks}
 \def\pgf@sys@addpdfresource@extgs@plain#1{\global\pgf@sys@pgf@resource@list@extgs@toks
   \expandafter{\the\pgf@sys@pgf@resource@list@extgs@toks #1}}

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -85,7 +85,7 @@ See source file '\inFileName' for licencing and contact information.
 %<*driver>
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesFile{luamplib.drv}%
-  [2015/05/04 v2.10.2 Interface for using the mplib library]%
+  [2015/05/06 v2.10.2 Interface for using the mplib library]%
 \documentclass{ltxdoc}
 \usepackage{metalogo,multicol,mdwlist,fancyvrb,xspace}
 \usepackage[x11names]{xcolor}
@@ -154,7 +154,7 @@ See source file '\inFileName' for licencing and contact information.
 % \author{Hans Hagen, Taco Hoekwater, Elie Roux, Philipp Gesang and Kim Dohyun\\
 % Maintainer: LuaLaTeX Maintainers ---
 % Support: \email{lualatex-dev@tug.org}}
-% \date{2015/05/04 v2.10.2}
+% \date{2015/05/06 v2.10.2}
 %
 % \maketitle
 %
@@ -366,7 +366,7 @@ luamplib.lastlog  = ""
 local err, warn, info, log = luatexbase.provides_module({
   name          = "luamplib",
   version       = "2.10.2",
-  date          = "2015/05/04",
+  date          = "2015/05/06",
   description   = "Lua package to typeset Metapost with LuaTeX's MPLib.",
 })
 
@@ -1675,7 +1675,7 @@ luamplib.colorconverter = colorconverter
 \else
   \NeedsTeXFormat{LaTeX2e}
   \ProvidesPackage{luamplib}
-    [2015/05/04 v2.10.2 mplib package for LuaTeX]
+    [2015/05/06 v2.10.2 mplib package for LuaTeX]
   \RequirePackage{luatexbase-modutils}
 \fi
 %    \end{macrocode}
@@ -1956,12 +1956,13 @@ luamplib.colorconverter = colorconverter
 \ifcsname selectfont\endcsname
   \AtBeginDocument{\@ifpackageloaded{pgfsys}{
     \directlua{luamplib.pgf_loaded=true}
-    \ifcase\pdfoutput\else\ifcsname pgf@sys@pgf@resource@list@extgs@toks\endcsname\else
-      \csname newtoks\endcsname\pgf@sys@pgf@resource@list@extgs@toks
-      \def\pgf@sys@pgf@resource@list@extgs{\the\pgf@sys@pgf@resource@list@extgs@toks}
-      \def\pgf@sys@addpdfresource@extgs@plain#1{\global\pgf@sys@pgf@resource@list@extgs@toks
-        \expandafter{\the\pgf@sys@pgf@resource@list@extgs@toks #1}}
-    \fi\fi
+    \ifcase\pdfoutput\else
+      \@ifpackageloaded{luaotfload}{}{
+        \csname newtoks\endcsname\pgf@sys@pgf@resource@list@extgs@toks
+        \def\pgf@sys@pgf@resource@list@extgs{\the\pgf@sys@pgf@resource@list@extgs@toks}
+        \def\pgf@sys@addpdfresource@extgs@plain#1{\global\pgf@sys@pgf@resource@list@extgs@toks
+          \expandafter{\the\pgf@sys@pgf@resource@list@extgs@toks #1}}}
+    \fi
   }{}}
 \endinput\fi
 \ifcsname pgf@sys@addpdfresource@extgs@plain\endcsname\else\endinput\fi

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -85,7 +85,7 @@ See source file '\inFileName' for licencing and contact information.
 %<*driver>
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesFile{luamplib.drv}%
-  [2015/06/03 v2.10.2 Interface for using the mplib library]%
+  [2015/06/09 v2.10.2 Interface for using the mplib library]%
 \documentclass{ltxdoc}
 \usepackage{metalogo,multicol,mdwlist,fancyvrb,xspace}
 \usepackage[x11names]{xcolor}
@@ -154,7 +154,7 @@ See source file '\inFileName' for licencing and contact information.
 % \author{Hans Hagen, Taco Hoekwater, Elie Roux, Philipp Gesang and Kim Dohyun\\
 % Maintainer: LuaLaTeX Maintainers ---
 % Support: \email{lualatex-dev@tug.org}}
-% \date{2015/06/03 v2.10.2}
+% \date{2015/06/09 v2.10.2}
 %
 % \maketitle
 %
@@ -366,7 +366,7 @@ luamplib.lastlog  = ""
 local err, warn, info, log = luatexbase.provides_module({
   name          = "luamplib",
   version       = "2.10.2",
-  date          = "2015/06/03",
+  date          = "2015/06/09",
   description   = "Lua package to typeset Metapost with LuaTeX's MPLib.",
 })
 
@@ -635,10 +635,16 @@ local randomseed = nil
 
 local mpkpse = kpse.new("luatex", "mpost")
 
+local special_ftype = {
+  pfb = "type1 fonts",
+  enc = "enc files",
+}
+
 local function finder(name, mode, ftype)
   if mode == "w" then
     return name
   else
+    ftype = special_ftype[ftype] or ftype
     local file = mpkpse:find_file(name,ftype)
     if file then
       if not lfstouch or ftype ~= "mp" or noneedtoreplace[name] then
@@ -1040,7 +1046,6 @@ def externalfigure primary filename =
   draw rawtextext("\includegraphics{"& filename &"}")
 enddef;
 def TEX = textext enddef;
-def fontmapfile primary filename = enddef;
 def specialVerbatimTeX (text t) = special "MPlibVerbTeX="&t; enddef;
 def normalVerbatimTeX  (text t) = special "PostMPlibVerbTeX="&t; enddef;
 let VerbatimTeX = specialVerbatimTeX;
@@ -1682,7 +1687,7 @@ luamplib.colorconverter = colorconverter
 \else
   \NeedsTeXFormat{LaTeX2e}
   \ProvidesPackage{luamplib}
-    [2015/06/03 v2.10.2 mplib package for LuaTeX]
+    [2015/06/09 v2.10.2 mplib package for LuaTeX]
   \RequirePackage{luatexbase-modutils}
 \fi
 %    \end{macrocode}

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -85,7 +85,7 @@ See source file '\inFileName' for licencing and contact information.
 %<*driver>
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesFile{luamplib.drv}%
-  [2015/06/09 v2.10.2 Interface for using the mplib library]%
+  [2015/06/27 v2.10.2 Interface for using the mplib library]%
 \documentclass{ltxdoc}
 \usepackage{metalogo,multicol,mdwlist,fancyvrb,xspace}
 \usepackage[x11names]{xcolor}
@@ -154,7 +154,7 @@ See source file '\inFileName' for licencing and contact information.
 % \author{Hans Hagen, Taco Hoekwater, Elie Roux, Philipp Gesang and Kim Dohyun\\
 % Maintainer: LuaLaTeX Maintainers ---
 % Support: \email{lualatex-dev@tug.org}}
-% \date{2015/06/09 v2.10.2}
+% \date{2015/06/27 v2.10.2}
 %
 % \maketitle
 %
@@ -366,7 +366,7 @@ luamplib.lastlog  = ""
 local err, warn, info, log = luatexbase.provides_module({
   name          = "luamplib",
   version       = "2.10.2",
-  date          = "2015/06/09",
+  date          = "2015/06/27",
   description   = "Lua package to typeset Metapost with LuaTeX's MPLib.",
 })
 
@@ -1288,10 +1288,9 @@ local function tr_pdf_pageresources(mode,opaq)
     if res ~= "" then
       local tpr = texget("pdfpageresources") -- respect luaotfload-colors
       local no_extgs = not stringfind(tpr,"/ExtGState<<.*>>")
-      local pgf_loaded = no_extgs and (luaotfload and luaotfload.pgf_loaded or luamplib.pgf_loaded)
-      if pgf_loaded and type(pgf_loaded) == "number" then
-        local res_toks = texgettoks(pgf_loaded)
-        texsettoks("global", pgf_loaded, res_toks..res)
+      local pgf_loaded = no_extgs and luamplib.pgf_loaded
+      if pgf_loaded then
+        texsprint(format("\\csname pgf@sys@addpdfresource@extgs@plain\\endcsname{%s}",res))
       else
         if no_extgs then
           tpr = tpr.."/ExtGState<<>>"
@@ -1687,7 +1686,7 @@ luamplib.colorconverter = colorconverter
 \else
   \NeedsTeXFormat{LaTeX2e}
   \ProvidesPackage{luamplib}
-    [2015/06/09 v2.10.2 mplib package for LuaTeX]
+    [2015/06/27 v2.10.2 mplib package for LuaTeX]
   \RequirePackage{luatexbase-modutils}
 \fi
 %    \end{macrocode}
@@ -1965,40 +1964,10 @@ luamplib.colorconverter = colorconverter
 %
 %    For compatibility with beamer class, which loads pgf package.
 %    \begin{macrocode}
-\ifcsname selectfont\endcsname
-  \AtBeginDocument{\@ifpackageloaded{pgfsys}{
-    \directlua{luamplib.pgf_loaded=true}
-    \ifcase\pdfoutput\else
-      \@ifpackageloaded{luaotfload}{}{
-        \csname newtoks\endcsname\pgf@sys@pgf@resource@list@extgs@toks
-        \directlua{luamplib.pgf_loaded=\the\allocationnumber}
-        \def\pgf@sys@pgf@resource@list@extgs{\the\pgf@sys@pgf@resource@list@extgs@toks}
-        \def\pgf@sys@addpdfresource@extgs@plain#1{\global\pgf@sys@pgf@resource@list@extgs@toks
-          \expandafter{\the\pgf@sys@pgf@resource@list@extgs@toks #1}}}
-    \fi
-  }{}}
-\endinput\fi
-\ifcsname pgf@sys@addpdfresource@extgs@plain\endcsname\else\endinput\fi
-%    \end{macrocode}
-%    for plain tex, pgf loaded.
-%    \begin{macrocode}
-\directlua{luamplib.pgf_loaded=true}
-\ifcase\pdfoutput\endinput\fi
-%    \end{macrocode}
-%    pgfsys-pdftex.def loaded. Not dvi mode
-%    \begin{macrocode}
-\ifcsname pgf@sys@pgf@resource@list@extgs@toks\endcsname\endinput\fi
-%    \end{macrocode}
-%    luaotfload.sty not loaded. So copied from it.
-%    \begin{macrocode}
-\count255=\the\catcode`@\relax
-\catcode`@=11\relax
-\newtoks\pgf@sys@pgf@resource@list@extgs@toks
-\directlua{luamplib.pgf_loaded=\the\allocationnumber}
-\def\pgf@sys@pgf@resource@list@extgs{\the\pgf@sys@pgf@resource@list@extgs@toks}
-\def\pgf@sys@addpdfresource@extgs@plain#1{\global\pgf@sys@pgf@resource@list@extgs@toks
-  \expandafter{\the\pgf@sys@pgf@resource@list@extgs@toks #1}}
-\catcode`@=\the\count255\relax
+\ifdefined\AtBeginDocument\else\def\AtBeginDocument#1{#1}\fi
+\AtBeginDocument{%
+  \ifcsname pgfutil@everybye\endcsname \directlua{luamplib.pgf_loaded=true}\fi
+}
 %    \end{macrocode}
 %
 %    That's all folks!

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -85,7 +85,7 @@ See source file '\inFileName' for licencing and contact information.
 %<*driver>
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesFile{luamplib.drv}%
-  [2015/06/27 v2.10.2 Interface for using the mplib library]%
+  [2015/08/01 v2.11.0 Interface for using the mplib library]%
 \documentclass{ltxdoc}
 \usepackage{metalogo,multicol,mdwlist,fancyvrb,xspace}
 \usepackage[x11names]{xcolor}
@@ -154,7 +154,7 @@ See source file '\inFileName' for licencing and contact information.
 % \author{Hans Hagen, Taco Hoekwater, Elie Roux, Philipp Gesang and Kim Dohyun\\
 % Maintainer: LuaLaTeX Maintainers ---
 % Support: \email{lualatex-dev@tug.org}}
-% \date{2015/06/27 v2.10.2}
+% \date{2015/08/01 v2.11.0}
 %
 % \maketitle
 %
@@ -328,6 +328,10 @@ See source file '\inFileName' for licencing and contact information.
 %     draw fullcircle scaled 2u;
 %   \endmplibcode
 %   \end{verbatim}
+% \item Starting with v2.11, users can issue |\mplibverbatim{enable}|, after which
+%   the contents of mplibcode environment will be read verbatim. As a result,
+%   users cannot use |btex| ... |etex|, |verbatimtex| ... |etex|, |\mpdim|, |\mpcolor|
+%   etc. All \TeX\ commands are not expanded and will be fed literally into the mplib process. 
 % \item At the end of package loading, \textsf{luamplib} searches
 %   |luamplib.cfg| and, if found, reads the file in automatically.
 %   Frequently used settings such as \cs{everymplib} or \cs{mplibcachedir}
@@ -365,8 +369,8 @@ luamplib.lastlog  = ""
 
 local err, warn, info, log = luatexbase.provides_module({
   name          = "luamplib",
-  version       = "2.10.2",
-  date          = "2015/06/27",
+  version       = "2.11.0",
+  date          = "2015/08/01",
   description   = "Lua package to typeset Metapost with LuaTeX's MPLib.",
 })
 
@@ -1689,7 +1693,7 @@ luamplib.colorconverter = colorconverter
 \else
   \NeedsTeXFormat{LaTeX2e}
   \ProvidesPackage{luamplib}
-    [2015/06/27 v2.10.2 mplib package for LuaTeX]
+    [2015/08/01 v2.11.0 mplib package for LuaTeX]
   \RequirePackage{luatexbase-modutils}
 \fi
 %    \end{macrocode}
@@ -1762,10 +1766,14 @@ luamplib.colorconverter = colorconverter
 }
 \long\def\mplibdocode#1\endmplibcode{%
   \endgroup
-  \edef\mplibtemp{\directlua{luamplib.protecttextext([===[\unexpanded{#1}]===])}}%
-  \directlua{ tex.sprint(luamplib.mpxcolors) }%
-  \directlua{luamplib.tempdata = luamplib.makeTEXboxes([===[\mplibtemp]===])}%
-  \directlua{luamplib.processwithTEXboxes(luamplib.tempdata)}%
+  \ifdefined\mplibverbatimYes
+    \directlua{luamplib.process([===[\the\everymplibtoks\detokenize{#1}\the\everyendmplibtoks]===],true)}%
+  \else
+    \edef\mplibtemp{\directlua{luamplib.protecttextext([===[\unexpanded{#1}]===])}}%
+    \directlua{ tex.sprint(luamplib.mpxcolors) }%
+    \directlua{luamplib.tempdata = luamplib.makeTEXboxes([===[\mplibtemp]===])}%
+    \directlua{luamplib.processwithTEXboxes(luamplib.tempdata)}%
+  \fi
   \endgroup
   \ifnum\mplibstartlineno<\inputlineno\expandafter\mplibreplacenewlinecs\fi
 }
@@ -1789,10 +1797,14 @@ luamplib.colorconverter = colorconverter
   \endgroup
   \toks@\expandafter{\the\toks@#1}%
   \def\mplibtemp@a{#2}\ifx\mplib@mplibcode\mplibtemp@a
-    \edef\mplibtemp{\directlua{luamplib.protecttextext([===[\the\toks@]===])}}%
-    \directlua{ tex.sprint(luamplib.mpxcolors) }%
-    \directlua{luamplib.tempdata=luamplib.makeTEXboxes([===[\mplibtemp]===])}%
-    \directlua{luamplib.processwithTEXboxes(luamplib.tempdata)}%
+    \ifdefined\mplibverbatimYes
+      \directlua{luamplib.process([===[\the\everymplibtoks\the\toks@\the\everyendmplibtoks]===],true)}%
+    \else
+      \edef\mplibtemp{\directlua{luamplib.protecttextext([===[\the\toks@]===])}}%
+      \directlua{ tex.sprint(luamplib.mpxcolors) }%
+      \directlua{luamplib.tempdata=luamplib.makeTEXboxes([===[\mplibtemp]===])}%
+      \directlua{luamplib.processwithTEXboxes(luamplib.tempdata)}%
+    \fi
     \end{mplibcode}%
     \ifnum\mplibstartlineno<\inputlineno
       \expandafter\expandafter\expandafter\mplibreplacenewlinebr
@@ -1802,6 +1814,16 @@ luamplib.colorconverter = colorconverter
   \fi
 }
 \fi
+\def\mplibverbatim#1{%
+  \begingroup
+  \def\mplibtempa{#1}\def\mplibtempb{enable}%
+  \expandafter\endgroup
+  \ifx\mplibtempa\mplibtempb
+    \let\mplibverbatimYes\relax
+  \else
+    \let\mplibverbatimYes\undefined
+  \fi
+}
 %    \end{macrocode}
 %
 %    \cs{everymplib} \& \cs{everyendmplib}: macros redefining

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -85,7 +85,7 @@ See source file '\inFileName' for licencing and contact information.
 %<*driver>
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesFile{luamplib.drv}%
-  [2015/05/06 v2.10.2 Interface for using the mplib library]%
+  [2015/06/03 v2.10.2 Interface for using the mplib library]%
 \documentclass{ltxdoc}
 \usepackage{metalogo,multicol,mdwlist,fancyvrb,xspace}
 \usepackage[x11names]{xcolor}
@@ -154,7 +154,7 @@ See source file '\inFileName' for licencing and contact information.
 % \author{Hans Hagen, Taco Hoekwater, Elie Roux, Philipp Gesang and Kim Dohyun\\
 % Maintainer: LuaLaTeX Maintainers ---
 % Support: \email{lualatex-dev@tug.org}}
-% \date{2015/05/06 v2.10.2}
+% \date{2015/06/03 v2.10.2}
 %
 % \maketitle
 %
@@ -366,7 +366,7 @@ luamplib.lastlog  = ""
 local err, warn, info, log = luatexbase.provides_module({
   name          = "luamplib",
   version       = "2.10.2",
-  date          = "2015/05/06",
+  date          = "2015/06/03",
   description   = "Lua package to typeset Metapost with LuaTeX's MPLib.",
 })
 
@@ -386,6 +386,7 @@ local stringgmatch  = string.gmatch
 local stringexplode = string.explode
 local tableconcat   = table.concat
 local texsprint     = tex.sprint
+local textprint     = tex.tprint
 
 local texget      = tex.get
 local texset      = tex.set
@@ -847,8 +848,12 @@ local function pdf_stopfigure()
   texsprint("\\mplibstoptoPDF")
 end
 
+%    \end{macrocode}
+%    |tex.tprint| and catcode regime -2, as sometimes |#| gets doubled
+%    in the argument of pdfliteral. --- modified by Kim
+%    \begin{macrocode}
 local function pdf_literalcode(fmt,...) -- table
-  texsprint(format("\\mplibtoPDF{%s}",format(fmt,...)))
+  textprint({"\\mplibtoPDF{"},{-2,format(fmt,...)},{"}"})
 end
 luamplib.pdf_literalcode = pdf_literalcode
 
@@ -1675,7 +1680,7 @@ luamplib.colorconverter = colorconverter
 \else
   \NeedsTeXFormat{LaTeX2e}
   \ProvidesPackage{luamplib}
-    [2015/05/06 v2.10.2 mplib package for LuaTeX]
+    [2015/06/03 v2.10.2 mplib package for LuaTeX]
   \RequirePackage{luatexbase-modutils}
 \fi
 %    \end{macrocode}

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -1263,6 +1263,8 @@ local transparancy_modes = { [0] = "Normal",
   "Compatible",
 }
 
+local pgf_loaded
+
 local function update_tr_res(res,mode,opaq)
   local os = format("<</BM /%s/ca %.3f/CA %.3f/AIS false>>",mode,opaq,opaq)
   local on, new = update_pdfobjs(os)
@@ -1270,7 +1272,7 @@ local function update_tr_res(res,mode,opaq)
     if pdfmode then
       res = format("%s/MPlibTr%i %i 0 R",res,on,on)
     else
-      if luamplib.pgf_loaded then
+      if pgf_loaded then
         texsprint(format("\\csname pgf@sys@addpdfresource@extgs@plain\\endcsname{/MPlibTr%i%s}",on,os))
       else
         texsprint(format("\\special{pdf:put @MPlibTr<</MPlibTr%i%s>>}",on,os))
@@ -1281,6 +1283,7 @@ local function update_tr_res(res,mode,opaq)
 end
 
 local function tr_pdf_pageresources(mode,opaq)
+  pgf_loaded = pgf_loaded or (newtoken and newtoken.create("pgfutil@everybye").cmdname == "assign_toks")
   local res, on_on, off_on = "", nil, nil
   res, off_on = update_tr_res(res, "Normal", 1)
   res, on_on  = update_tr_res(res, mode, opaq)
@@ -1288,8 +1291,8 @@ local function tr_pdf_pageresources(mode,opaq)
     if res ~= "" then
       local tpr = texget("pdfpageresources") -- respect luaotfload-colors
       local no_extgs = not stringfind(tpr,"/ExtGState<<.*>>")
-      local pgf_loaded = no_extgs and luamplib.pgf_loaded
-      if pgf_loaded then
+      local pgf_pdf_loaded = no_extgs and pgf_loaded
+      if pgf_pdf_loaded then
         texsprint(format("\\csname pgf@sys@addpdfresource@extgs@plain\\endcsname{%s}",res))
       else
         if no_extgs then
@@ -1300,7 +1303,7 @@ local function tr_pdf_pageresources(mode,opaq)
       end
     end
   else
-    if not luamplib.pgf_loaded then
+    if not pgf_loaded then
       texsprint(format("\\special{pdf:put @resources<</ExtGState @MPlibTr>>}"))
     end
   end
@@ -1960,14 +1963,6 @@ luamplib.colorconverter = colorconverter
   \closein0
   \input luamplib.cfg
 \fi
-%    \end{macrocode}
-%
-%    For compatibility with beamer class, which loads pgf package.
-%    \begin{macrocode}
-\ifdefined\AtBeginDocument\else\def\AtBeginDocument#1{#1}\fi
-\AtBeginDocument{%
-  \ifcsname pgfutil@everybye\endcsname \directlua{luamplib.pgf_loaded=true}\fi
-}
 %    \end{macrocode}
 %
 %    That's all folks!

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -85,7 +85,7 @@ See source file '\inFileName' for licencing and contact information.
 %<*driver>
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesFile{luamplib.drv}%
-  [2015/03/26 v2.10.1 Interface for using the mplib library]%
+  [2015/05/04 v2.10.2 Interface for using the mplib library]%
 \documentclass{ltxdoc}
 \usepackage{metalogo,multicol,mdwlist,fancyvrb,xspace}
 \usepackage[x11names]{xcolor}
@@ -154,7 +154,7 @@ See source file '\inFileName' for licencing and contact information.
 % \author{Hans Hagen, Taco Hoekwater, Elie Roux, Philipp Gesang and Kim Dohyun\\
 % Maintainer: LuaLaTeX Maintainers ---
 % Support: \email{lualatex-dev@tug.org}}
-% \date{2015/03/26 v2.10.1}
+% \date{2015/05/04 v2.10.2}
 %
 % \maketitle
 %
@@ -365,8 +365,8 @@ luamplib.lastlog  = ""
 
 local err, warn, info, log = luatexbase.provides_module({
   name          = "luamplib",
-  version       = "2.10.1",
-  date          = "2015/03/26",
+  version       = "2.10.2",
+  date          = "2015/05/04",
   description   = "Lua package to typeset Metapost with LuaTeX's MPLib.",
 })
 
@@ -386,6 +386,12 @@ local stringgmatch  = string.gmatch
 local stringexplode = string.explode
 local tableconcat   = table.concat
 local texsprint     = tex.sprint
+
+local texget      = tex.get
+local texset      = tex.set
+local texgettoks  = tex.gettoks
+local texsettoks  = tex.settoks
+local texgetbox   = tex.getbox
 
 local mplib = require ('mplib')
 local kpse  = require ('kpse')
@@ -1052,8 +1058,8 @@ enddef;
 luamplib.textextlabelpreamble = textextlabelpreamble
 
 local function protecttextext(data)
-  local everymplib    = tex.toks['everymplibtoks']    or ''
-  local everyendmplib = tex.toks['everyendmplibtoks'] or ''
+  local everymplib    = texgettoks('everymplibtoks')    or ''
+  local everyendmplib = texgettoks('everyendmplibtoks') or ''
   data = "\n" .. everymplib .."\n".. data .."\n".. everyendmplib
   data = stringgsub(data,"\r","\n")
   data = stringgsub(data, "\"[^\n]-\"",
@@ -1158,7 +1164,7 @@ local function processwithTEXboxes (data)
   local prepreamble = format("TEXBOX_:=%i;\n",num)
   while true do
     num = num + 1
-    local box = tex.box[num]
+    local box = texgetbox(num)
     if not box then break end
     prepreamble = format(
       "%sTEXBOX_wd_[%i]:=%f;\nTEXBOX_ht_[%i]:=%f;\nTEXBOX_dp_[%i]:=%f;\n",
@@ -1171,7 +1177,7 @@ local function processwithTEXboxes (data)
 end
 luamplib.processwithTEXboxes = processwithTEXboxes
 
-local pdfmode = tex.pdfoutput > 0 and true or false
+local pdfmode = texget("pdfoutput") > 0 and true or false
 
 local function start_pdf_code()
   if pdfmode then
@@ -1254,7 +1260,11 @@ local function update_tr_res(res,mode,opaq)
     if pdfmode then
       res = format("%s/MPlibTr%i %i 0 R",res,on,on)
     else
-      texsprint(format("\\special{pdf:put @MPlibTr<</MPlibTr%i%s>>}",on,os))
+      if luamplib.pgf_loaded then
+        texsprint(format("\\special{pdf:put @pgfextgs<</MPlibTr%i%s>>}",on,os))
+      else
+        texsprint(format("\\special{pdf:put @MPlibTr<</MPlibTr%i%s>>}",on,os))
+      end
     end
   end
   return res,on
@@ -1266,15 +1276,22 @@ local function tr_pdf_pageresources(mode,opaq)
   res, on_on  = update_tr_res(res, mode, opaq)
   if pdfmode then
     if res ~= "" then
-      local tpr = tex.pdfpageresources -- respect luaotfload-colors
-      if not stringfind(tpr,"/ExtGState<<.*>>") then
-        tpr = tpr.."/ExtGState<<>>"
+      if luamplib.pgf_loaded then
+        local res_toks = texgettoks("pgf@sys@pgf@resource@list@extgs@toks")
+        texsettoks("global", "pgf@sys@pgf@resource@list@extgs@toks", res_toks..res)
+      else
+        local tpr = texget("pdfpageresources") -- respect luaotfload-colors
+        if not stringfind(tpr,"/ExtGState<<.*>>") then
+          tpr = tpr.."/ExtGState<<>>"
+        end
+        tpr = stringgsub(tpr,"/ExtGState<<","%1"..res)
+        texset("global","pdfpageresources",tpr)
       end
-      tpr = stringgsub(tpr,"/ExtGState<<","%1"..res)
-      tex.set("global","pdfpageresources",tpr)
     end
   else
-    texsprint(format("\\special{pdf:put @resources<</ExtGState @MPlibTr>>}"))
+    if not luamplib.pgf_loaded then
+      texsprint(format("\\special{pdf:put @resources<</ExtGState @MPlibTr>>}"))
+    end
   end
   return on_on, off_on
 end
@@ -1653,12 +1670,12 @@ luamplib.colorconverter = colorconverter
 %
 %    \begin{macrocode}
 \bgroup\expandafter\expandafter\expandafter\egroup
-\expandafter\ifx\csname ProvidesPackage\endcsname\relax
+\expandafter\ifx\csname selectfont\endcsname\relax
   \input luatexbase-modutils.sty
 \else
   \NeedsTeXFormat{LaTeX2e}
   \ProvidesPackage{luamplib}
-    [2015/03/26 v2.10.1 mplib package for LuaTeX]
+    [2015/05/04 v2.10.2 mplib package for LuaTeX]
   \RequirePackage{luatexbase-modutils}
 \fi
 %    \end{macrocode}
@@ -1932,6 +1949,41 @@ luamplib.colorconverter = colorconverter
   \closein0
   \input luamplib.cfg
 \fi
+%    \end{macrocode}
+%
+%    For compatibility with beamer class, which loads pgf package.
+%    \begin{macrocode}
+\ifcsname selectfont\endcsname
+  \AtBeginDocument{\@ifpackageloaded{pgfsys}{
+    \directlua{luamplib.pgf_loaded=true}
+    \ifcase\pdfoutput\else\ifcsname pgf@sys@pgf@resource@list@extgs@toks\endcsname\else
+      \csname newtoks\endcsname\pgf@sys@pgf@resource@list@extgs@toks
+      \def\pgf@sys@pgf@resource@list@extgs{\the\pgf@sys@pgf@resource@list@extgs@toks}
+      \def\pgf@sys@addpdfresource@extgs@plain#1{\global\pgf@sys@pgf@resource@list@extgs@toks
+        \expandafter{\the\pgf@sys@pgf@resource@list@extgs@toks #1}}
+    \fi\fi
+  }{}}
+\endinput\fi
+\ifcsname pgf@sys@addpdfresource@extgs@plain\endcsname\else\endinput\fi
+%    \end{macrocode}
+%    for plain tex, pgf loaded.
+%    \begin{macrocode}
+\directlua{luamplib.pgf_loaded=true}
+\ifcsname pgf@sys@pgf@resource@list@extgs\endcsname\else\endinput\fi
+%    \end{macrocode}
+%    pgfsys-pdftex.def loaded. Not dvi mode
+%    \begin{macrocode}
+\ifcsname pgf@sys@pgf@resource@list@extgs@toks\endcsname\endinput\fi
+%    \end{macrocode}
+%    luaotfload.sty not loaded. So copied from it.
+%    \begin{macrocode}
+\count255=\the\catcode`@\relax
+\catcode`@=11\relax
+\newtoks\pgf@sys@pgf@resource@list@extgs@toks
+\def\pgf@sys@pgf@resource@list@extgs{\the\pgf@sys@pgf@resource@list@extgs@toks}
+\def\pgf@sys@addpdfresource@extgs@plain#1{\global\pgf@sys@pgf@resource@list@extgs@toks
+  \expandafter{\the\pgf@sys@pgf@resource@list@extgs@toks #1}}
+\catcode`@=\the\count255\relax
 %    \end{macrocode}
 %
 %    That's all folks!


### PR DESCRIPTION
* after `\mplibverbatim{enable}`, contents of mplibcode environment
      will be read verbatim. So `btex ... etex`, `verbatimtex ... etex`,
      `\mpdim`, `\mpcolor` are not allowed and all TeX commands will be
      fed literally into mplib library.
* allow access to type1 fonts, which means we can use glyph
      operator now (luatex rev 5266)
* color transparency is now compatible with pgf package and
      beamer class as well. (luatex 0.80+ is recommended)
