### PR TITLE
Fix compat with Lua 5.3 based LuaTeX

### DIFF
--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -1622,7 +1622,7 @@ local function flush(result,flusher)
                   end
                   local dl = object.dash
                   if dl then
-                    local d = format("[%s] %i d",tableconcat(dl.dashes or {}," "),dl.offset)
+                    local d = format("[%s] %f d",tableconcat(dl.dashes or {}," "),dl.offset)
                     if d ~= dashed then
                       dashed = d
                       pdf_literalcode(dashed)


### PR DESCRIPTION
dash pattern offset is very likely not an integer, so use `%f` instead
of `%i` to format it.

To reproduce this problem, use LuaTeX built with lua 5.3 to build the following plain TeX file:
```
\input luamplib.sty
\mplibcode
beginfig(0);
draw ((0,0)--(100,100)) dashed withdots;
endfig;
\endmplibcode
\end
```
