### PR TITLE
v2.20.0

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,16 +1,18 @@
                        History of the luamplib package
 
 2019/03/20 2.20.0
-    * huge changes, but mostly internal, so not much differ from old one
+    * huge changes, but mostly internal, so apparently not much difference
+      from the old.
     * '\mpliblegacybehavior{disable}' triggers a new mode of processing
       verbatimtex .. etex: along with btex .. etex, they will be processed
-      sequentially one by one. By contrast, Old behavior, being default,
-      processes all btex .. etex things first; after that,
-      verbatimtex .. etex before beginfig() is processed just before mplib
-      figure box; finally verbatimtex .. etex inside beginfig() .. endfig
-      is processed. Incidentally, verbatimtex .. etex in input mp files
-      is honored from now on, save when they contain '\documentclass' or
-      '\begin{document}' etc.
+      sequentially one by one.
+      By contrast, old behavior, being default, processes all btex .. etex
+      things first; after that, verbatimtex .. etex before beginfig() is
+      processed just before mplib figure box; finally verbatimtex .. etex
+      inside beginfig() .. endfig is processed after the box.
+      Incidentally, verbatimtex .. etex in MP input files is honored
+      from this version, save those that contain '\documentclass'
+      or '\begin{document}' etc, which is totally ignored.
 
 2018/09/27 2.12.5
     * change dash.offset pattern from "%i" to "%f" (PR #77)

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,17 @@
                        History of the luamplib package
 
+2019/03/20 2.20.0
+    * huge changes, but mostly internal, so not much differ from old one
+    * '\mpliblegacybehavior{disable}' triggers a new mode of processing
+      verbatimtex .. etex: along with btex .. etex, they will be processed
+      sequentially one by one. By contrast, Old behavior, being default,
+      processes all btex .. etex things first; after that,
+      verbatimtex .. etex before beginfig() is processed just before mplib
+      figure box; finally verbatimtex .. etex inside beginfig() .. endfig
+      is processed. Incidentally, verbatimtex .. etex in input mp files
+      is honored from now on, save when they contain '\documentclass' or
+      '\begin{document}' etc.
+
 2018/09/27 2.12.5
     * change dash.offset pattern from "%i" to "%f" (PR #77)
     * remove unnecessary variables that go back to context (issue #76)

--- a/NEWS
+++ b/NEWS
@@ -2,14 +2,13 @@
 
 2019/03/20 2.20.0
     * huge changes, but mostly internal, so apparently not much difference
-      from the old.
+      from previous version.
+    * '\mplibforcehmode' makes mplibcode typeset in horizontal mode.
+      '\mplibnoforcehmode' reverts the setting. The latter is default.
     * '\mpliblegacybehavior{disable}' triggers a new mode of processing
       verbatimtex .. etex: along with btex .. etex, they will be processed
-      sequentially one by one.
-      By contrast, old behavior, being default, processes all btex .. etex
-      things first; after that, verbatimtex .. etex before beginfig() is
-      processed just before mplib figure box; finally verbatimtex .. etex
-      inside beginfig() .. endfig is processed after the box.
+      sequentially one by one. Old behavior, being default, can be restored
+      by declaring '\mpliblegacybehavior{enable}'.
       Incidentally, verbatimtex .. etex in MP input files is honored
       from this version, save those that contain '\documentclass'
       or '\begin{document}' etc, which is totally ignored.

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -158,13 +158,13 @@ See source file '\inFileName' for licencing and contact information.
 % \maketitle
 %
 % \begin{abstract}
-% Package to have metapost code typeset directly in a document with Lua\TeX .
+% Package to have metapost code typeset directly in a document with \LuaTeX.
 % \end{abstract}
 %
 % \section{Documentation}
 %
 % This packages aims at providing a simple way to typeset directly metapost
-% code in a document with \LuaTeX . \LuaTeX\ is built with the lua
+% code in a document with \LuaTeX. \LuaTeX\ is built with the lua
 % \texttt{mplib} library, that runs metapost code. This package is basically a
 % wrapper (in Lua) for the Lua \texttt{mplib} functions and some \TeX\
 % functions to have the output of the \texttt{mplib} functions in the pdf.
@@ -194,15 +194,29 @@ See source file '\inFileName' for licencing and contact information.
 %   |textext()| is a more versatile macro equivalent to |TEX()| from TEX.mp.
 %   |TEX()| is also allowed and is a synomym of |textext()|.\par\smallskip
 %   \textsc{n.b.} Since v2.5, |btex ... etex| input from external |mp| files
-%   will also be processed by \textsf{luamplib}. However,
-%   |verbatimtex ... etex| will be entirely ignored in this case.
-% \item |verbatimtex ... etex| (in \TeX\ file) that comes just before |beginfig()|
-%   is not ignored, but the \TeX\ code inbetween will be inserted before the
+%   will also be processed by \textsf{luamplib}.\par\smallskip
+%   \textsc{n.b.} Since v2.20, |verbatimtex ... etex| from external |mp| files
+%    will be also processed by \textsf{luamplib}. Warning: This is a change
+%   from previous version.
+% \end{itemize}
+%
+% Some more changes and cuations are:
+%
+% \paragraph{\cs{mplibforcehmode}}
+%   When this macro is declared, every mplibcode figure box will be
+%   typeset in horizontal mode, so \cs{centering}, \cs{raggedleft} etc
+%   will have effects. |\mplibnoforcehmode|, being default, reverts this
+%   setting.
+%
+% \paragraph{\cs{mpliblegacybehavior\{enable\}}}
+%   By default, |\mpliblegacybehavior{enable}| is already declared,
+%   in which case
+%   a |verbatimtex ... etex| that comes just before |beginfig()|
+%   is not ignored, but the \TeX\ code will be inserted before the
 %   following mplib hbox.  Using this command,
 %   each mplib box can be freely moved horizontally and/or vertically.
 %   Also, a box number might be assigned to mplib box, allowing it to be
 %   reused later (see test files).
-%   \textsc{e.g.}
 %   \begin{verbatim}
 %     \mplibcode
 %     verbatimtex \moveright 3cm etex; beginfig(0); ... endfig;
@@ -213,11 +227,10 @@ See source file '\inFileName' for licencing and contact information.
 %   \end{verbatim}
 %   \textsc{n.b.} \cs{endgraf} should be used instead of \cs{par} inside
 %   |verbatimtex ... etex|.
-% \item
-%   \TeX\ code in |VerbatimTeX(...)| or |verbatimtex ... etex| (in \TeX\ file)
+%
+%   By contrast, \TeX\ code in |VerbatimTeX(...)| or |verbatimtex ... etex|
 %   between |beginfig()| and |endfig| will be inserted
 %   after flushing out the mplib figure.
-%   \textsc{e.g.}
 %   \begin{verbatim}
 %     \mplibcode
 %       D := sqrt(2)**7;
@@ -228,32 +241,48 @@ See source file '\inFileName' for licencing and contact information.
 %     \endmplibcode
 %     diameter: \Dia bp.
 %   \end{verbatim}
-% \item Notice that, after each figure is processed, macro \cs{MPwidth} stores
+%
+% \paragraph{\cs{mpliblegacybehavior\{disable\}}}
+%   If |\mpliblegacybehavior{disabled}| is declared by user, any
+%   |verbatimtex ... etex| will be executed, along with |btex ... etex|,
+%   sequentially one by one.
+%   So, some \TeX\ code in |verbatimtex ... etex| will have effects on
+%   |btex ... etex| codes that follows.
+%   \begin{verbatim}
+%     \begin{mplibcode}
+%       beginfig(0);
+%       draw btex ABC etex;
+%       verbatimtex \bfseries etex;
+%       draw btex DEF etex shifted (1cm,0); % bold face
+%       draw btex GHI etex shifted (2cm,0); % bold face
+%       endfig;
+%     \end{mplibcode}
+%   \end{verbatim}
+%
+% \paragraph{About figure box metrics}
+%   Notice that, after each figure is processed, macro \cs{MPwidth} stores
 %   the width value of latest figure; \cs{MPheight}, the height value.
 %   Incidentally, also note that \cs{MPllx}, \cs{MPlly}, \cs{MPurx}, and
 %   \cs{MPury} store the bounding box information of latest figure
 %   without the unit |bp|.
-% \item Since v2.3, new macros \cs{everymplib} and \cs{everyendmplib} redefine
+%
+% \paragraph{\cs{everymplib}, \cs{everyendmplib}}
+%   Since v2.3, new macros \cs{everymplib} and \cs{everyendmplib} redefine
 %   token lists \cs{everymplibtoks} and \cs{everyendmplibtoks} respectively,
 %   which will
 %   be automatically inserted at the beginning and ending of each mplib code.
-%   \textsc{e.g.}
 %   \begin{verbatim}
-%     \everymplib{ verbatimtex \leavevmode etex; beginfig(0); }
+%     \everymplib{ beginfig(0); }
 %     \everyendmplib{ endfig; }
-%     \mplibcode % beginfig/endfig not needed; always in horizontal mode
+%     \mplibcode % beginfig/endfig not needed
 %       draw fullcircle scaled 1cm;
 %     \endmplibcode
 %   \end{verbatim}
-%   \textsc{n.b.} Many users have complained that mplib figures do not
-%   respect alignment commands such as \cs{centering} or \cs{raggedleft}.
-%   That's because \textsf{luamplib} does not force horizontal or vertical mode.
-%   If you want all mplib figures center- (or right-) aligned, please use
-%   \cs{everymplib} command with \cs{leavevmode} as shown above.
-% \item Since v2.3, \cs{mpdim} and other raw \TeX\ commands are allowed
+%
+% \paragraph{\cs{mpdim}}
+%   Since v2.3, \cs{mpdim} and other raw \TeX\ commands are allowed
 %   inside mplib code. This feature is inpired by gmp.sty authored by
 %   Enrico Gregorio. Please refer the manual of gmp package for details.
-%   \textsc{e.g.}
 %   \begin{verbatim}
 %     \begin{mplibcode}
 %       draw origin--(\mpdim{\linewidth},0) withpen pencircle scaled 4
@@ -264,17 +293,24 @@ See source file '\inFileName' for licencing and contact information.
 %   |btex ... etex| as provided by gmp package. As \textsf{luamplib}
 %   automatically protects \TeX\ code inbetween, \cs{btex} is not supported
 %   here.
-% \item With \cs{mpcolor} command, color names or expressions of
+%
+% \paragraph{\cs{mpcolor}}
+%   With \cs{mpcolor} command, color names or expressions of
 %   \textsf{color}/\textsf{xcolor} packages can be used inside mplibcode
 %   enviroment, though \textsf{luamplib} does not automatically load these
 %   packages. See the example code above. For spot colors, \textsf{(x)spotcolor}
 %   (in PDF mode) and \textsf{xespotcolor} (in DVI mode) packages are supported
 %   as well.
-% \item Users can choose |numbersystem| option since v2.4.
-%   The default value |scaled| can be changed to |double| by declaring
-%   |\mplibnumbersystem{double}|. For details see
+%
+% \paragraph{\cs{mplibnumbersystem}}
+%   Users can choose |numbersystem| option since v2.4.
+%   The default value |scaled| can be changed to |double| or |decimal|
+%   by declaring |\mplibnumbersystem{double}| or |\mplibnumbersystem{decimal}|.
+%   For details see
 %   \url{http://github.com/lualatex/luamplib/issues/21}.
-% \item To support |btex ... etex| in external |.mp| files, \textsf{luamplib}
+%
+% \paragraph{Settings regarding cache files}
+%   To support |btex ... etex| in external |.mp| files, \textsf{luamplib}
 %   inspects the content of each and every |.mp| input files and makes caches
 %   if nececcsary, before returning their paths to \LuaTeX's mplib library.
 %   This would make the compilation time longer wastefully, as most |.mp| files
@@ -288,14 +324,17 @@ See source file '\inFileName' for licencing and contact information.
 %   where |<filename>| is a file name excluding |.mp| extension.
 %   Note that |.mp| files under |$TEXMFMAIN/metapost/base| and
 %   |$TEXMFMAIN/metapost/context/base| are already registered by default.
-% \item By default, cache files will be stored in |$TEXMFVAR/luamplib_cache|
-%   or, if it's not available, in the same directory as where pdf/dvi output file
+%
+%   By default, cache files will be stored in |$TEXMFVAR/luamplib_cache| or,
+%   if it's not available, in the same directory as where pdf/dvi output file
 %   is saved. This however can be changed by the command
 %   |\mplibcachedir{<directory path>}|, where tilde (|~|) is interpreted
 %   as the user's home directory (on a windows machine as well).
 %   As backslashes (|\|) should be escaped by users, it would be easier to use
 %   slashes (|/|) instead.
-% \item Starting with v2.6, |\mplibtextextlabel{enable}| enables
+%
+% \paragraph{\cs{mplibtextextlabel}}
+%   Starting with v2.6, |\mplibtextextlabel{enable}| enables
 %   string labels typeset via |textext()| instead of |infont| operator.
 %   So, |label("my text",origin)| thereafter is exactly the same as
 %   |label(textext("my text"),origin)|. \textsc{n.b.} In the background,
@@ -304,13 +343,15 @@ See source file '\inFileName' for licencing and contact information.
 %   therefore will be typeset with current \TeX\ font.
 %   Also take care of |char| operator in the left side argument,
 %   as this might bring unpermitted characters into \TeX.
-% \item Starting with v2.9, |\mplibcodeinherit{enable}| enables the inheritance
+%
+% \paragraph{\cs{mplibcodeinherit}}
+%   Starting with v2.9, |\mplibcodeinherit{enable}| enables the inheritance
 %   of variables, constants, and macros defined by previous |mplibcode| chunks.
 %   On the contrary, the default value |\mplibcodeinherit{disable}| will make
 %   each code chunks being treated as an independent instance, and never
 %   affected by previous code chunks.
 %
-%   \textsc{n.b.}
+% \paragraph{\cs{mplibglobaltextext}}
 %   To inherit |btex ... etex| labels as well as metapost variables,
 %   it is necessary to declare \cs{mplibglobaltextext\{enable\}} in advance.
 %   On this case, be careful that normal \TeX\ boxes can conflict with
@@ -331,17 +372,22 @@ See source file '\inFileName' for licencing and contact information.
 %     currentpicture := pic scaled 2;
 %   \endmplibcode
 %   \end{verbatim}
-% \item Starting with v2.11, users can issue |\mplibverbatim{enable}|, after which
+%
+% \paragraph{\cs{mplibverbatim}}
+%   Starting with v2.11, users can issue |\mplibverbatim{enable}|, after which
 %   the contents of mplibcode environment will be read verbatim. As a result,
-%   users cannot use |\mpdim|, |\mpcolor| etc. All \TeX\ commands outside of
+%   users cannot use |\mpdim|, but |\mpcolor| is OK.
+%   All other \TeX\ commands outside
 %   |btex ... etex| or |verbatimtex ... etex| are not expanded and will be fed
 %   literally into the mplib process.
-% \item At the end of package loading, \textsf{luamplib} searches
+%
+% \paragraph{luamplib.cfg}
+%   At the end of package loading, \textsf{luamplib} searches
 %   |luamplib.cfg| and, if found, reads the file in automatically.
-%   Frequently used settings such as \cs{everymplib} or \cs{mplibcachedir}
+%   Frequently used settings such as \cs{everymplib} or \cs{mplibforcehmode}
 %   are suitable for going into this file.
 %
-% \end{itemize}
+% \bigskip
 %
 % There are (basically) two formats for metapost: \emph{plain} and
 % \emph{metafun}. By default, the \emph{plain} format is used, but you can set
@@ -355,16 +401,8 @@ See source file '\inFileName' for licencing and contact information.
 % \iffalse
 %<*lua>
 % \fi
-%    Use the |luamplib| namespace, since |mplib| is for the metapost library
-%    itself. \ConTeXt{} uses |metapost|.
 %
 %    \begin{macrocode}
-
-luamplib          = luamplib or { }
-local luamplib    = luamplib
-
-luamplib.showlog  = luamplib.showlog or false
-luamplib.lastlog  = ""
 
 luatexbase.provides_module {
   name          = "luamplib",
@@ -379,6 +417,22 @@ local err  = function(...) return luatexbase.module_error  ("luamplib", format(.
 local warn = function(...) return luatexbase.module_warning("luamplib", format(...)) end
 local info = function(...) return luatexbase.module_info   ("luamplib", format(...)) end
 
+%    \end{macrocode}
+%
+%    Use the |luamplib| namespace, since |mplib| is for the metapost library
+%    itself. \ConTeXt{} uses |metapost|.
+%    \begin{macrocode}
+luamplib          = luamplib or { }
+local luamplib    = luamplib
+
+luamplib.showlog  = luamplib.showlog or false
+luamplib.lastlog  = ""
+
+%    \end{macrocode}
+%
+%    This module is a stripped down version of libraries that are used by
+%    \ConTeXt. Provide a few ``shortcuts'' expected by the imported code.
+%    \begin{macrocode}
 local tableconcat   = table.concat
 local texsprint     = tex.sprint
 local textprint     = tex.tprint
@@ -403,6 +457,11 @@ local lfsmkdir      = lfs.mkdir
 local lfstouch      = lfs.touch
 local ioopen        = io.open
 
+%    \end{macrocode}
+%
+%    Some helper functions, prepared for the case when |l-file| etc
+%    is not loaded.
+%    \begin{macrocode}
 local file = file or { }
 local replacesuffix = file.replacesuffix or function(filename, suffix)
   return (filename:gsub("%.[%a%d]+$","")) .. "." .. suffix
@@ -429,6 +488,12 @@ local mk_full_path = lfs.mkdirs or function(path)
   end
 end
 
+%    \end{macrocode}
+%
+%    |btex ... etex| in input |.mp| files will be replaced in finder.
+%    Because of the limitation of MPLib regarding |make_text|,
+%    we might have to make cache files modified from input files.
+%    \begin{macrocode}
 local luamplibtime = kpse.find_file("luamplib.lua")
 luamplibtime = luamplibtime and lfsattributes(luamplibtime,"modification")
 
@@ -479,6 +544,10 @@ function luamplib.getcachedir(dir)
   end
 end
 
+%    \end{macrocode}
+%
+%    Some basic MetaPost files not necessary to make cache files.
+%    \begin{macrocode}
 local noneedtoreplace = {
   ["boxes.mp"] = true, --  ["format.mp"] = true,
   ["graph.mp"] = true, ["marith.mp"] = true, ["mfplain.mp"] = true,
@@ -497,6 +566,10 @@ local noneedtoreplace = {
 }
 luamplib.noneedtoreplace = noneedtoreplace
 
+%    \end{macrocode}
+%
+%    |format.mp| is much complicated, so specially treated.
+%    \begin{macrocode}
 local function replaceformatmp(file,newfile,ofmodify)
   local fh = ioopen(file,"r")
   if not fh then return file end
@@ -515,6 +588,11 @@ local function replaceformatmp(file,newfile,ofmodify)
   return newfile
 end
 
+%    \end{macrocode}
+%
+%    Replace |btex ... etex| and |verbatimtex ... etex| in input files,
+%    if needed.
+%    \begin{macrocode}
 local name_b = "%f[A-Z_a-z]"
 local name_e = "%f[^A-Z_a-z]"
 local btex_etex = name_b.."btex"..name_e.."%s*(.-)%s*"..name_b.."etex"..name_e
@@ -540,6 +618,11 @@ local function replaceinputmpfile (name,file)
   if not fh then return file end
   local data = fh:read("*all"); fh:close()
 
+%    \end{macrocode}
+%
+%    ``|etex|'' must be followed by a space or semicolon as specified in
+%    \LuaTeX\ manual, which is not the case of standalone MetaPost though.
+%    \begin{macrocode}
   local count,cnt = 0,0
   data, cnt = data:gsub(btex_etex, "btex %1 etex ") -- space
   count = count + cnt
@@ -563,6 +646,12 @@ local function replaceinputmpfile (name,file)
   return newfile
 end
 
+%    \end{macrocode}
+%
+%    As the finder function for MPLib, use the |kpse| library and
+%    make it behave like as if MetaPost was used. And replace it with
+%    cache files if needed.
+%    \begin{macrocode}
 local mpkpse = kpse.new(arg[0], "mpost")
 
 local special_ftype = {
@@ -587,12 +676,16 @@ local function finder(name, mode, ftype)
 end
 luamplib.finder = finder
 
-function luamplib.resetlastlog()
-  luamplib.lastlog = ""
-end
-
+%    \end{macrocode}
+%
+%    Create and load MPLib instances.
+%    We do not support ancient version of MPLib any more.
+%    (Don't know which version of MPLib started to support
+%    |make_text| and |run_script|; let the users find it.)
+%    \begin{macrocode}
 if tonumber(mplib.version()) <= 1.50 then
-  err("luamplib no longer supports mplib v1.50 or lower")
+  err("luamplib no longer supports mplib v1.50 or lower. "..
+  "Please upgrade to the latest version of LuaTeX")
 end
 
 local preamble = [[
@@ -601,6 +694,10 @@ local preamble = [[
   let normalfontsize = fontsize;
   input %s ;
 ]]
+
+local function luamplibresetlastlog()
+  luamplib.lastlog = ""
+end
 
 local function reporterror (result)
   if not result then
@@ -624,11 +721,24 @@ local function luamplibload (name)
   local mpx = mplib.new {
     ini_version = true,
     find_file   = luamplib.finder,
+%    \end{macrocode}
+%
+%    Make use of |make_text| and |run_script|, which will co-operate
+%    with \LuaTeX's |tex.runtoks|. And we
+%    provide |numbersystem| option since v2.4. Default value ``|scaled|''
+%    can be changed by declaring |\mplibnumbersystem{double}|
+%    or |\mplibnumbersystem{decimal}|.
+%    See \url{https://github.com/lualatex/luamplib/issues/21}.
+%    \begin{macrocode}
     make_text   = luamplib.maketext,
     run_script  = luamplib.runscript,
     math_mode   = luamplib.numbersystem,
     extensions  = 1,
   }
+%    \end{macrocode}
+%
+%    Append our own MetaPost preamble to the preamble above.
+%    \begin{macrocode}
   local preamble = preamble .. luamplib.mplibcodepreamble
   if luamplib.legacy_verbatimtex then
     preamble = preamble .. luamplib.legacyverbatimtexpreamble
@@ -646,6 +756,11 @@ local function luamplibload (name)
   return mpx, result
 end
 
+%    \end{macrocode}
+%
+%    |plain| or |metafun|,
+%    though we cannot support |metafun| format fully.
+%    \begin{macrocode}
 local currentformat = "plain"
 
 local function setformat (name)
@@ -653,6 +768,11 @@ local function setformat (name)
 end
 luamplib.setformat = setformat
 
+%    \end{macrocode}
+%
+%    Here, excute each |mplibcode| data,
+%    ie |\begin{mplibcode} ... \end{mplibcode}|.
+%    \begin{macrocode}
 local function process_indeed (mpx, data)
   local converted, result = false, {}
   if mpx and data then
@@ -661,8 +781,15 @@ local function process_indeed (mpx, data)
     if log then
       if luamplib.showlog then
         info("%s",luamplib.lastlog)
-        luamplib.resetlastlog()
+        luamplibresetlastlog()
       elseif result.fig then
+%    \end{macrocode}
+%
+%    v2.6.1: now luamplib does not disregard |show| command,
+%    even when |luamplib.showlog| is false.  Incidentally,
+%    it does not raise error but just prints a warning,
+%    even if output has no figure.
+%    \begin{macrocode}
         if log:find("\n>>") then info("%s",log) end
         converted = luamplib.convert(result)
       else
@@ -676,10 +803,18 @@ local function process_indeed (mpx, data)
   return converted, result
 end
 
+%    \end{macrocode}
+%
+%    v2.9 has introduced the concept of ``code inherit''
+%    \begin{macrocode}
 luamplib.codeinherit = false
 local mplibinstances = {}
 
 local function process (data)
+%    \end{macrocode}
+%
+%    Workaround issue \#70
+%    \begin{macrocode}
   if not data:find(name_b.."beginfig%s*%([%+%-%s]*%d[%.%d%s]*%)") then
     data = data .. "beginfig(-1);endfig;"
   end
@@ -697,9 +832,20 @@ local function process (data)
   return process_indeed(mpx, data)
 end
 
+%    \end{macrocode}
+%
+%    |make_text| and some |run_script| uses \LuaTeX's |tex.runtoks|,
+%    which made possible running \TeX\ code snippets inside |\directlua|.
+%    \begin{macrocode}
 local catlatex = luatexbase.registernumber("catcodetable@latex")
 local catat11  = luatexbase.registernumber("catcodetable@atletter")
 
+%    \end{macrocode}
+%
+%    |tex.scantoks| sometimes fail to read catcode properly, especially
+%    |\#|, |\&|, or |\%|. After some experiment, we dropped using it.
+%    Instead, a function containing |tex.script| seems to work nicely.
+%    \begin{macrocode}
 local function run_tex_code_no_use (str, cat)
   cat = cat or catlatex
   texscantoks("mplibtmptoks", cat, str)
@@ -711,7 +857,19 @@ local function run_tex_code (str, cat)
   texruntoks(function() texsprint(cat, str) end)
 end
 
+%    \end{macrocode}
+%
+%    Indefinite number of boxes are needed for |btex ... etex|.
+%    So starts at somewhat huge number of box registry. Of course,
+%    this may conflict with other packages using many many boxes.
+%    (When |codeinherit| feature is enabled, boxes must be globally defined.)
+%    But I don't know any reliable way to escape this danger.
+%    \begin{macrocode}
 local tex_box_id = 2047
+%    \end{macrocode}
+%
+%    For conversion of |sp| to |bp|.
+%    \begin{macrocode}
 local factor = 65536*(7227/7200)
 
 local function process_tex_text (str)
@@ -731,6 +889,11 @@ local function process_tex_text (str)
   return ""
 end
 
+%    \end{macrocode}
+%
+%    Make |color| or |xcolor|'s color expressions usable,
+%    with \cs{mpcolor} or |mplibcolor|
+%    \begin{macrocode}
 local function process_color (str)
   if str then
     if not str:find("{.-}") then
@@ -744,6 +907,13 @@ local function process_color (str)
   return ""
 end
 
+%    \end{macrocode}
+%
+%    \cs{mpdim} is expanded before MPLib process, so code below will not be
+%    used for |mplibcode| data. But who knows anyone would want it
+%    in |.mp| input file. If then, you can say |mplibdimen(".5\textwidth")|
+%    for example.
+%    \begin{macrocode}
 local function process_dimen (str)
   if str then
     str = str:gsub("{(.+)}","%1")
@@ -753,6 +923,11 @@ local function process_dimen (str)
   return ""
 end
 
+%    \end{macrocode}
+%
+%    Newly introduced method of processing |verbatimtex ... etex|.
+%    Used when |\mpliblegacybehavior{false}| is declared.
+%    \begin{macrocode}
 local function process_verbatimtex_text (str)
   if str then
     run_tex_code(str)
@@ -760,7 +935,13 @@ local function process_verbatimtex_text (str)
   return ""
 end
 
--- for legacy verbatimtex process
+%    \end{macrocode}
+%
+%    For legacy verbatimtex process.
+%    |verbatimtex ... etex| before |beginfig()| is not ignored,
+%    but the \TeX\ code is inserted just before the mplib box. And
+%    \TeX\ code inside |beginfig() ... endfig| is inserted after the mplib box.
+%    \begin{macrocode}
 local tex_code_pre_mplib = {}
 luamplib.figid = 1
 luamplib.in_the_fig = false
@@ -793,6 +974,21 @@ local runscript_funcs = {
   luamplibverbtex = process_verbatimtex_text,
 }
 
+%    \end{macrocode}
+%
+%    As of 2019-03, |metafun| format is not usable (issue \#79).
+%    This might workarounds the problem.
+%    \begin{macrocode}
+mp = mp or {}
+local mp = mp
+mp.mf_path_reset = mp.mf_path_reset or function() end
+mp.mf_finish_saving_data = mp.mf_finish_saving_data or function() end
+LUATEXFUNCTIONALITY = LUATEXFUNCTIONALITY or 0
+
+%    \end{macrocode}
+%
+%    A function from \ConTeXt\ general.
+%    \begin{macrocode}
 local function mpprint(buffer,...)
   for i=1,select("#",...) do
     local value = select(i,...)
@@ -810,13 +1006,6 @@ local function mpprint(buffer,...)
     end
   end
 end
-
--- for metafun
-mp = mp or {}
-local mp = mp
-mp.mf_path_reset = mp.mf_path_reset or function() end
-mp.mf_finish_saving_data = mp.mf_finish_saving_data or function() end
-LUATEXFUNCTIONALITY = LUATEXFUNCTIONALITY or 0
 
 function luamplib.runscript (code)
   local id, str = code:match("(.-){(.+)}")
@@ -839,6 +1028,10 @@ function luamplib.runscript (code)
   return ""
 end
 
+%    \end{macrocode}
+%
+%    |make_text| must be one liner, so comment sign is not allowed.
+%    \begin{macrocode}
 local function protecttexcontents (str)
   return str:gsub("\\%%", "\0PerCent\0")
             :gsub("%%.-\n", "")
@@ -874,6 +1067,10 @@ function luamplib.maketext (str, what)
   return ""
 end
 
+%    \end{macrocode}
+%
+%    Our MetaPost preambles
+%    \begin{macrocode}
 local mplibcodepreamble = [[
 texscriptmode := 2;
 def rawtextext (expr t) = runscript("luamplibtext{"&t&"}") enddef;
@@ -937,8 +1134,17 @@ enddef;
 ]]
 luamplib.textextlabelpreamble = textextlabelpreamble
 
+%    \end{macrocode}
+%
+%    When \cs{mplibverbatim} is enabled, do not expand |mplibcode| data.
+%    \begin{macrocode}
 luamplib.verbatiminput = false
 
+%    \end{macrocode}
+%
+%    Do not expand |btex ... etex|, |verbatimtex ... etex|, and
+%    string expressions.
+%    \begin{macrocode}
 local function protect_expansion (str)
   if str then
     str = str:gsub("\\","\1Control\1")
@@ -961,6 +1167,10 @@ local function unprotect_expansion (str)
 end
 
 local function process_mplibcode (data)
+%    \end{macrocode}
+%
+%    This is needed for legacy behavior regarding |verbatimtex|
+%    \begin{macrocode}
   legacy_mplibcode_reset()
 
   local everymplib    = texgettoks('everymplibtoks')    or ''
@@ -979,11 +1189,21 @@ local function process_mplibcode (data)
       luamplib.verbatiminput and str or protect_expansion(str))
   end)
 
+%    \end{macrocode}
+%
+%    If not |mplibverbatim|, expand |mplibcode| data,
+%    so that users can use \TeX\ codes in it.
+%    It has turned out that no comment sign is allowed.
+%    \begin{macrocode}
   if not luamplib.verbatiminput then
     data = data:gsub("\".-\"", protect_expansion)
     data = data:gsub("%%.-\n","")
     run_tex_code(format("\\toks0\\expanded{{%s}}",data))
     data = texgettoks(0)
+%    \end{macrocode}
+%
+%    Next line to address issue \#55
+%    \begin{macrocode}
     data = data:gsub("##", "#")
     data = data:gsub("\".-\"", unprotect_expansion)
     data = data:gsub(btex_etex, function(str)
@@ -998,6 +1218,10 @@ local function process_mplibcode (data)
 end
 luamplib.process_mplibcode = process_mplibcode
 
+%    \end{macrocode}
+%
+%    For parsing |prescript| materials.
+%    \begin{macrocode}
 local further_split_keys = {
   ["mplibtexboxid"] = true,
   ["sh_color_a"]    = true,
@@ -1019,6 +1243,11 @@ local function script2table(s)
   return t
 end
 
+%    \end{macrocode}
+%
+%    Codes below for inserting PDF lieterals are mostly from ConTeXt general,
+%    with small changes when needed.
+%    \begin{macrocode}
 local function getobjects(result,figure,f)
   return figure:objects()
 end
@@ -1037,12 +1266,16 @@ local function pdf_stopfigure()
   texsprint("\\mplibstoptoPDF")
 end
 
+%    \end{macrocode}
+%
+%    |tex.tprint| with catcode regime -2, as sometimes |#| gets doubled
+%    in the argument of pdfliteral.
+%    \begin{macrocode}
 local function pdf_literalcode(fmt,...) -- table
   textprint({"\\mplibtoPDF{"},{-2,format(fmt,...)},{"}"})
 end
 
 local function pdf_textfigure(font,size,text,width,height,depth)
-  -- if text == "" then text = "\0" end -- char(0) has gone
   text = text:gsub(".",function(c)
     return format("\\hbox{\\char%i}",string.byte(c)) -- kerning happens in metapost
   end)
@@ -1095,8 +1328,7 @@ local function flushnormalpath(path,open)
     else
       pdf_literalcode("%f %f l",one.x_coord,one.y_coord)
     end
-  elseif #path == 1 then
-    -- special case .. draw point
+  elseif #path == 1 then -- special case .. draw point
     local one = path[1]
     pdf_literalcode("%f %f l",one.x_coord,one.y_coord)
   end
@@ -1127,13 +1359,16 @@ local function flushconcatpath(path,open)
     else
       pdf_literalcode("%f %f l",concat(one.x_coord,one.y_coord))
     end
-  elseif #path == 1 then
-    -- special case .. draw point
+  elseif #path == 1 then -- special case .. draw point
     local one = path[1]
     pdf_literalcode("%f %f l",concat(one.x_coord,one.y_coord))
   end
 end
 
+%    \end{macrocode}
+%
+%    |dvipdfmx| is supported, though nobody seems to use it.
+%    \begin{macrocode}
 local pdfoutput = tonumber(texget("outputmode")) or tonumber(texget("pdfoutput"))
 local pdfmode = pdfoutput > 0
 
@@ -1152,6 +1387,11 @@ local function stop_pdf_code()
   end
 end
 
+%    \end{macrocode}
+%
+%    Now we process hboxes created from |btex ... etex| or
+%    |textext(...)| or |TEX(...)|, all being the same internally.
+%    \begin{macrocode}
 local function put_tex_boxes (object,prescript)
   local box = prescript.mplibtexboxid
   local n,tw,th = box[1],tonumber(box[2]),tonumber(box[3])
@@ -1177,6 +1417,10 @@ local function put_tex_boxes (object,prescript)
   end
 end
 
+%    \end{macrocode}
+%
+%    Colors and Transparency
+%    \begin{macrocode}
 local pdf_objs = {}
 local token, getpageres, setpageres = newtoken or token
 local pgf = { bye = "pgfutil@everybye", extgs = "pgf@sys@addpdfresource@extgs@plain" }
@@ -1189,7 +1433,6 @@ else
             "\\special{pdf:obj @MPlibSh<<>>}")
 end
 
--- objstr <string> => obj <number>, new <boolean>
 local function update_pdfobjs (os)
   local on = pdf_objs[os]
   if on then
@@ -1259,11 +1502,15 @@ local function tr_pdf_pageresources(mode,opaq)
   return on_on, off_on
 end
 
+%    \end{macrocode}
+%
+%    Shading with |metafun| format. (maybe legacy way)
+%    \begin{macrocode}
 local shading_res
 
 local function shading_initialize ()
   shading_res = {}
-  if pdfmode and luatexbase.callbacktypes and luatexbase.callbacktypes.finish_pdffile then -- ltluatex
+  if pdfmode and luatexbase.callbacktypes.finish_pdffile then -- ltluatex
     local shading_obj = pdf.reserveobj()
     setpageres(format("%s/Shading %i 0 R",getpageres() or "",shading_obj))
     luatexbase.add_to_callback("finish_pdffile", function()
@@ -1319,7 +1566,10 @@ end
 local prev_override_color
 
 local function do_preobj_color(object,prescript)
-  -- transparency
+%    \end{macrocode}
+%
+%    transparency
+%    \begin{macrocode}
   local opaq = prescript and prescript.tr_transparency
   local tron_no, troff_no
   if opaq then
@@ -1328,7 +1578,10 @@ local function do_preobj_color(object,prescript)
     tron_no, troff_no = tr_pdf_pageresources(mode,opaq)
     pdf_literalcode("/MPlibTr%i gs",tron_no)
   end
-  -- color
+%    \end{macrocode}
+%
+%    color
+%    \begin{macrocode}
   local override = prescript and prescript.MPlibOverrideColor
   if override then
     if pdfmode then
@@ -1350,7 +1603,10 @@ local function do_preobj_color(object,prescript)
       end
     end
   end
-  -- shading
+%    \end{macrocode}
+%
+%    shading
+%    \begin{macrocode}
   local sh_type = prescript and prescript.sh_type
   if sh_type then
     local domain  = prescript.sh_domain
@@ -1411,6 +1667,10 @@ local function do_postobj_color(tr,over,sh)
   end
 end
 
+%    \end{macrocode}
+%
+%    Finally, flush figures by inserting PDF literals.
+%    \begin{macrocode}
 local function flush(result,flusher)
   if result then
     local figures = result.fig
@@ -1424,14 +1684,27 @@ local function flush(result,flusher)
         local bbox = figure:boundingbox()
         local llx, lly, urx, ury = bbox[1], bbox[2], bbox[3], bbox[4] -- faster than unpack
         if urx < llx then
-          -- invalid
-          -- pdf_startfigure(fignum,0,0,0,0)
-          -- pdf_stopfigure()
+%    \end{macrocode}
+%
+%    luamplib silently ignores this invalid figure for those
+%    that do not contain |beginfig ... endfig|. (issue \#70)
+%    Original code of ConTeXt general was:
+%    \begin{verbatim}
+%    -- invalid
+%    pdf_startfigure(fignum,0,0,0,0)
+%    pdf_stopfigure()
+%    \end{verbatim}
+%    \begin{macrocode}
         else
+%    \end{macrocode}
+%
+%    For legacy behavior. Insert `pre-fig' \TeX\ code here, and
+%    prepare a table for `in-fig' codes.
+%    \begin{macrocode}
           if tex_code_pre_mplib[f] then
             texsprint(tex_code_pre_mplib[f])
           end
-          local TeX_code_bot = {} -- PostVerbatimTeX
+          local TeX_code_bot = {}
           pdf_startfigure(fignum,llx,lly,urx,ury)
           start_pdf_code()
           if objects then
@@ -1440,13 +1713,17 @@ local function flush(result,flusher)
             for o=1,#objects do
               local object        = objects[o]
               local objecttype    = object.type
+%    \end{macrocode}
+%
+%    The following 5 lines are part of |btex...etex| patch.
+%    Again, colors are processed at this stage.
+%    \begin{macrocode}
               local prescript     = object.prescript
               prescript = prescript and script2table(prescript) -- prescript is now a table
               local tr_opaq,cr_over,shade_no = do_preobj_color(object,prescript)
               if prescript and prescript.mplibtexboxid then
                 put_tex_boxes(object,prescript)
-              elseif objecttype == "start_bounds" or objecttype == "stop_bounds" then
-                -- skip
+              elseif objecttype == "start_bounds" or objecttype == "stop_bounds" then --skip
               elseif objecttype == "start_clip" then
                 local evenodd = not object.istext and object.postscript == "evenodd"
                 start_pdf_code()
@@ -1456,6 +1733,11 @@ local function flush(result,flusher)
                 stop_pdf_code()
                 miterlimit, linecap, linejoin, dashed = -1, -1, -1, false
               elseif objecttype == "special" then
+%    \end{macrocode}
+%
+%    Collect \TeX\ codes that will be executed after flushing.
+%    Legacy behavior.
+%    \begin{macrocode}
                 if prescript and prescript.postmplibverbtex then
                   TeX_code_bot[#TeX_code_bot+1] = prescript.postmplibverbtex
                 end
@@ -1550,7 +1832,11 @@ local function flush(result,flusher)
                     else
                       flushnormalpath(path,open)
                     end
-                    if not shade_no then ----- conflict with shading
+%    \end{macrocode}
+%
+%    Change from ConTeXt general: there was color stuffs.
+%    \begin{macrocode}
+                    if not shade_no then -- conflict with shading
                       if objecttype == "fill" then
                         pdf_literalcode(evenodd and "h f*" or "h f")
                       elseif objecttype == "outline" then
@@ -1602,6 +1888,11 @@ local function flush(result,flusher)
                   end
                 end
               end
+%    \end{macrocode}
+%
+%    Added to ConTeXt general: color stuff.
+%    And execute legacy |verbatimtex| code.
+%    \begin{macrocode}
               do_postobj_color(tr_opaq,cr_over,shade_no)
             end
           end
@@ -1637,6 +1928,7 @@ luamplib.colorconverter = colorconverter
 %
 %    \subsection{\texorpdfstring{\TeX}{TeX} package}
 %
+%
 %    \begin{macrocode}
 %<*package>
 %    \end{macrocode}
@@ -1655,7 +1947,15 @@ luamplib.colorconverter = colorconverter
   \input ltluatex
   \fi
 \fi
+%    \end{macrocode}
+%
+%    Loading of lua code.
+%    \begin{macrocode}
 \directlua{require("luamplib")}
+%    \end{macrocode}
+%
+%    Support older engine. Seems we don't need it, but no harm.
+%    \begin{macrocode}
 \ifx\scantextokens\undefined
   \let\scantextokens\luatexscantextokens
 \fi
@@ -1664,8 +1964,17 @@ luamplib.colorconverter = colorconverter
   \protected\def\pdfliteral{\pdfextension literal}
   \def\pdffontsize{\dimexpr\pdffeedback fontsize\relax}
 \fi
-
+%    \end{macrocode}
+%
+%    Set the format for metapost.
+%    \begin{macrocode}
 \def\mplibsetformat#1{\directlua{luamplib.setformat("#1")}}
+%    \end{macrocode}
+%
+%    luamplib works in both PDF and DVI mode,
+%    but only DVIPDFMx is supported currently among a number of DVI tools.
+%    So we output a warning.
+%    \begin{macrocode}
 \ifnum\pdfoutput>0
   \let\mplibtoPDF\pdfliteral
 \else
@@ -1678,16 +1987,32 @@ luamplib.colorconverter = colorconverter
     \write128{}
   \fi
 \fi
+%    \end{macrocode}
+%
+%    Make |mplibcode| typesetted always in horizontal mode.
+%    \begin{macrocode}
 \def\mplibforcehmode{\let\mplibhmodeornot\leavevmode}
 \def\mplibnoforcehmode{\let\mplibhmodeornot\relax}
 \mplibnoforcehmode
+%    \end{macrocode}
+%
+%    Catcode. We want to allow comment sign in |mplibcode|.
+%    \begin{macrocode}
 \def\mplibsetupcatcodes{%
-  \mplibhmodeornot
-  %catcode`\{=12 %catcode`\}=12
+  \mplibhmodeornot %catcode`\{=12 %catcode`\}=12
   \catcode`\#=12 \catcode`\^=12 \catcode`\~=12 \catcode`\_=12
   \catcode`\&=12 \catcode`\$=12 \catcode`\%=12 \catcode`\^^M=12 \endlinechar=10
 }
+%    \end{macrocode}
+%
+%    Make |btex...etex| box zero-metric.
+%    \begin{macrocode}
 \def\mplibputtextbox#1{\vbox to 0pt{\vss\hbox to 0pt{\raise\dp#1\copy#1\hss}}}
+%    \end{macrocode}
+%
+%    As we have changed |^^J| catcode, the last line containing
+%    |\end{mplibcode}| has |\n| at the end. Replace it with |^^M|.
+%    \begin{macrocode}
 \newcount\mplibstartlineno
 \def\mplibpostmpcatcodes{%
   \catcode`\{=12 \catcode`\}=12 \catcode`\#=12 \catcode`\%=12 }
@@ -1695,6 +2020,10 @@ luamplib.colorconverter = colorconverter
   \begingroup \mplibpostmpcatcodes \mplibdoreplacenewlinebr}
 \begingroup\lccode`\~=`\^^M \lowercase{\endgroup
   \def\mplibdoreplacenewlinebr#1^^J{\endgroup\scantextokens{{}#1~}}}
+%    \end{macrocode}
+%
+%    The Plain-specific stuff.
+%    \begin{macrocode}
 \bgroup\expandafter\expandafter\expandafter\egroup
 \expandafter\ifx\csname selectfont\endcsname\relax
 \def\mplibreplacenewlinecs{%
@@ -1715,6 +2044,10 @@ luamplib.colorconverter = colorconverter
   \ifnum\mplibstartlineno<\inputlineno\expandafter\mplibreplacenewlinecs\fi
 }
 \else
+%    \end{macrocode}
+%
+%    The \LaTeX-specific part: a new environment.
+%    \begin{macrocode}
 \newenvironment{mplibcode}{%
   \global\mplibstartlineno\inputlineno
   \toks@{}\ltxdomplibcode
@@ -1740,6 +2073,10 @@ luamplib.colorconverter = colorconverter
   \fi
 }
 \fi
+%    \end{macrocode}
+%
+%    User settings.
+%    \begin{macrocode}
 \def\mpliblegacybehavior#1{\directlua{
     local s = string.lower("#1")
     if s == "enable" or s == "true" or s == "yes" then
@@ -1756,6 +2093,11 @@ luamplib.colorconverter = colorconverter
       luamplib.verbatiminput = false
     end
 }}
+%    \end{macrocode}
+%
+%    \cs{everymplib} \& \cs{everyendmplib}: macros redefining
+%    \cs{everymplibtoks} \& \cs{everyendmplibtoks} respectively
+%    \begin{macrocode}
 \newtoks\mplibtmptoks
 \newtoks\everymplibtoks
 \newtoks\everyendmplibtoks
@@ -1781,12 +2123,24 @@ luamplib.colorconverter = colorconverter
   \everyendmplibtoks{#1}%
   \ifnum\mplibstartlineno<\inputlineno\expandafter\mplibreplacenewlinebr\fi
 }
+%    \end{macrocode}
+%
+%    Allow \TeX\ dimen macros in |mplibcode|.
+%    \begin{macrocode}
 \def\mpdim#1{ begingroup \the\dimexpr #1\relax\space endgroup } % gmp.sty
+%    \end{macrocode}
+%
+%    MPLib's number system. Now |binary| has gone away.
+%    \begin{macrocode}
 \def\mplibnumbersystem#1{\directlua{
   local t = "#1"
   if t == "binary" then t = "decimal" end
   luamplib.numbersystem = t
 }}
+%    \end{macrocode}
+%
+%    Settings for |.mp| cache files.
+%    \begin{macrocode}
 \def\mplibmakenocache#1{\mplibdomakenocache #1,*,}
 \def\mplibdomakenocache#1,{%
   \ifx\empty#1\empty
@@ -1810,6 +2164,10 @@ luamplib.colorconverter = colorconverter
   \fi
 }
 \def\mplibcachedir#1{\directlua{luamplib.getcachedir("\unexpanded{#1}")}}
+%    \end{macrocode}
+%
+%    More user settings.
+%    \begin{macrocode}
 \def\mplibtextextlabel#1{\directlua{
     local s = string.lower("#1")
     if s == "enable" or s == "true" or s == "yes" then
@@ -1834,7 +2192,16 @@ luamplib.colorconverter = colorconverter
       luamplib.globaltextext = false
     end
 }}
+%    \end{macrocode}
+%
+%    The followings are from ConTeXt general, mostly.
+%    %    We use a dedicated scratchbox.
+%    \begin{macrocode}
 \ifx\mplibscratchbox\undefined \newbox\mplibscratchbox \fi
+%    \end{macrocode}
+%
+%    We encapsulate the litterals.
+%    \begin{macrocode}
 \def\mplibstarttoPDF#1#2#3#4{%
   \hbox\bgroup
   \xdef\MPllx{#1}\xdef\MPlly{#2}%
@@ -1866,6 +2233,10 @@ luamplib.colorconverter = colorconverter
   \box\mplibscratchbox
   \egroup
 }
+%    \end{macrocode}
+%
+%    Text items have a special handler.
+%    \begin{macrocode}
 \def\mplibtextext#1#2#3#4#5{%
   \begingroup
   \setbox\mplibscratchbox\hbox
@@ -1882,6 +2253,10 @@ luamplib.colorconverter = colorconverter
   \box\mplibscratchbox
   \endgroup
 }
+%    \end{macrocode}
+%
+%    Input |luamplib.cfg| when it exists.
+%    \begin{macrocode}
 \openin0=luamplib.cfg
 \ifeof0 \else
   \closein0

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -389,6 +389,10 @@ local texgetbox   = tex.getbox
 local texruntoks  = tex.runtoks
 local texscantoks = tex.scantoks
 
+if not texruntoks then
+  err("Your LuaTeX version is too old. Please upgrade it to the latest")
+end
+
 local mplib = require ('mplib')
 local kpse  = require ('kpse')
 local lfs   = require ('lfs')
@@ -1732,26 +1736,22 @@ luamplib.colorconverter = colorconverter
   \fi
 }
 \fi
-\def\mpliblegacybehavior#1{%
-  \begingroup
-  \def\mplibtempa{#1}\def\mplibtempb{enable}%
-  \expandafter\endgroup
-  \ifx\mplibtempa\mplibtempb
-    \directlua{luamplib.legacy_verbatimtex = true}%
-  \else
-    \directlua{luamplib.legacy_verbatimtex = false}%
-  \fi
-}
-\def\mplibverbatim#1{%
-  \begingroup
-  \def\mplibtempa{#1}\def\mplibtempb{enable}%
-  \expandafter\endgroup
-  \ifx\mplibtempa\mplibtempb
-    \directlua{luamplib.verbatiminput = true}%
-  \else
-    \directlua{luamplib.verbatiminput = false}%
-  \fi
-}
+\def\mpliblegacybehavior#1{\directlua{
+    local s = string.lower("#1")
+    if s == "enable" or s == "true" or s == "yes" then
+      luamplib.legacy_verbatimtex = true
+    else
+      luamplib.legacy_verbatimtex = false
+    end
+}}
+\def\mplibverbatim#1{\directlua{
+    local s = string.lower("#1")
+    if s == "enable" or s == "true" or s == "yes" then
+      luamplib.verbatiminput = true
+    else
+      luamplib.verbatiminput = false
+    end
+}}
 \newtoks\mplibtmptoks
 \newtoks\everymplibtoks
 \newtoks\everyendmplibtoks
@@ -1806,36 +1806,30 @@ luamplib.colorconverter = colorconverter
   \fi
 }
 \def\mplibcachedir#1{\directlua{luamplib.getcachedir("\unexpanded{#1}")}}
-\def\mplibtextextlabel#1{%
-  \begingroup
-  \def\tempa{enable}\def\tempb{#1}%
-  \ifx\tempa\tempb
-    \directlua{luamplib.textextlabel = true}%
-  \else
-    \directlua{luamplib.textextlabel = false}%
-  \fi
-  \endgroup
-}
-\def\mplibcodeinherit#1{%
-  \begingroup
-  \def\tempa{enable}\def\tempb{#1}%
-  \ifx\tempa\tempb
-    \directlua{luamplib.codeinherit = true}%
-  \else
-    \directlua{luamplib.codeinherit = false}%
-  \fi
-  \endgroup
-}
-\def\mplibglobaltextext#1{%
-  \begingroup
-  \def\tempa{enable}\def\tempb{#1}%
-  \ifx\tempa\tempb
-    \directlua{luamplib.globaltextext = true}%
-  \else
-    \directlua{luamplib.globaltextext = false}%
-  \fi
-  \endgroup
-}
+\def\mplibtextextlabel#1{\directlua{
+    local s = string.lower("#1")
+    if s == "enable" or s == "true" or s == "yes" then
+      luamplib.textextlabel = true
+    else
+      luamplib.textextlabel = false
+    end
+}}
+\def\mplibcodeinherit#1{\directlua{
+    local s = string.lower("#1")
+    if s == "enable" or s == "true" or s == "yes" then
+      luamplib.codeinherit = true
+    else
+      luamplib.codeinherit = false
+    end
+}}
+\def\mplibglobaltextext#1{\directlua{
+    local s = string.lower("#1")
+    if s == "enable" or s == "true" or s == "yes" then
+      luamplib.globaltextext = true
+    else
+      luamplib.globaltextext = false
+    end
+}}
 \ifx\mplibscratchbox\undefined \newbox\mplibscratchbox \fi
 \def\mplibstarttoPDF#1#2#3#4{%
   \hbox\bgroup

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -1678,7 +1678,11 @@ luamplib.colorconverter = colorconverter
     \write128{}
   \fi
 \fi
+\def\mplibforcehmode{\let\mplibhmodeornot\leavevmode}
+\def\mplibnoforcehmode{\let\mplibhmodeornot\relax}
+\mplibnoforcehmode
 \def\mplibsetupcatcodes{%
+  \mplibhmodeornot
   %catcode`\{=12 %catcode`\}=12
   \catcode`\#=12 \catcode`\^=12 \catcode`\~=12 \catcode`\_=12
   \catcode`\&=12 \catcode`\$=12 \catcode`\%=12 \catcode`\^^M=12 \endlinechar=10

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -1,6 +1,6 @@
 % \iffalse meta-comment -- by the way, this file contains UTF-8
 %
-% Copyright (C) 2008-2018 by Hans Hagen, Taco Hoekwater, Elie Roux,
+% Copyright (C) 2008-2019 by Hans Hagen, Taco Hoekwater, Elie Roux,
 % Manuel Pégourié-Gonnard, Philipp Gesang and Kim Dohyun.
 % Currently maintained by the LuaLaTeX development team.
 % Support: <lualatex-dev@tug.org>
@@ -85,7 +85,7 @@ See source file '\inFileName' for licencing and contact information.
 %<*driver>
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesFile{luamplib.drv}%
-  [2018/09/27 v2.12.5 Interface for using the mplib library]%
+  [2019/03/20 v2.20.0 Interface for using the mplib library]%
 \documentclass{ltxdoc}
 \usepackage{metalogo,multicol,mdwlist,fancyvrb,xspace}
 \usepackage[x11names]{xcolor}
@@ -153,7 +153,7 @@ See source file '\inFileName' for licencing and contact information.
 % \author{Hans Hagen, Taco Hoekwater, Elie Roux, Philipp Gesang and Kim Dohyun\\
 % Maintainer: LuaLaTeX Maintainers ---
 % Support: \email{lualatex-dev@tug.org}}
-% \date{2018/09/27 v2.12.5}
+% \date{2019/03/20 v2.20.0}
 %
 % \maketitle
 %
@@ -361,28 +361,17 @@ See source file '\inFileName' for licencing and contact information.
 %    \begin{macrocode}
 
 luamplib          = luamplib or { }
-
-%    \end{macrocode}
-%    Identification.
-%
-%    \begin{macrocode}
-
 local luamplib    = luamplib
+
 luamplib.showlog  = luamplib.showlog or false
 luamplib.lastlog  = ""
 
 luatexbase.provides_module {
   name          = "luamplib",
-  version       = "2.12.5",
-  date          = "2018/09/27",
+  version       = "2.20.0",
+  date          = "2019/03/20",
   description   = "Lua package to typeset Metapost with LuaTeX's MPLib.",
 }
-
-%    \end{macrocode}
-%    This module is a stripped down version of libraries that are used by
-%    \ConTeXt. Provide a few ``shortcuts'' expected by the imported code.
-%
-%    \begin{macrocode}
 
 local format, abs = string.format, math.abs
 
@@ -390,11 +379,6 @@ local err  = function(...) return luatexbase.module_error  ("luamplib", format(.
 local warn = function(...) return luatexbase.module_warning("luamplib", format(...)) end
 local info = function(...) return luatexbase.module_info   ("luamplib", format(...)) end
 
-local stringgsub    = string.gsub
-local stringfind    = string.find
-local stringmatch   = string.match
-local stringgmatch  = string.gmatch
-local stringexplode = string.explode
 local tableconcat   = table.concat
 local texsprint     = tex.sprint
 local textprint     = tex.tprint
@@ -402,6 +386,8 @@ local textprint     = tex.tprint
 local texget      = tex.get
 local texgettoks  = tex.gettoks
 local texgetbox   = tex.getbox
+local texruntoks  = tex.runtoks
+local texscantoks = tex.scantoks
 
 local mplib = require ('mplib')
 local kpse  = require ('kpse')
@@ -414,24 +400,13 @@ local lfstouch      = lfs.touch
 local ioopen        = io.open
 
 local file = file or { }
-%    \end{macrocode}
-%    This is a small trick for \LaTeX . In \LaTeX\ we read the metapost code
-%    line by line, but it needs to be passed entirely to |process()|, so we
-%    simply add the lines in |data| and at the end we call |process(data)|.
-%
-%    A few helpers, taken from |l-file.lua|.
-%
-%    \begin{macrocode}
 local replacesuffix = file.replacesuffix or function(filename, suffix)
-  return (stringgsub(filename,"%.[%a%d]+$","")) .. "." .. suffix
+  return (filename:gsub("%.[%a%d]+$","")) .. "." .. suffix
 end
 local stripsuffix = file.stripsuffix or function(filename)
-  return (stringgsub(filename,"%.[%a%d]+$",""))
+  return (filename:gsub("%.[%a%d]+$",""))
 end
 
-%    \end{macrocode}
-%     |btex ... etex| in input .mp files will be replaced in finder.
-%    \begin{macrocode}
 local is_writable = file.is_writable or function(name)
   if lfsisdir(name) then
     name = name .. "/_luam_plib_temp_file_"
@@ -444,7 +419,7 @@ local is_writable = file.is_writable or function(name)
 end
 local mk_full_path = lfs.mkdirs or function(path)
   local full = ""
-  for sub in stringgmatch(path,"(/*[^\\/]+)") do
+  for sub in path:gmatch("(/*[^\\/]+)") do
     full = full .. sub
     lfsmkdir(full)
   end
@@ -459,7 +434,7 @@ local outputdir
 if lfstouch then
   local texmfvar = kpse.expand_var('$TEXMFVAR')
   if texmfvar and texmfvar ~= "" and texmfvar ~= '$TEXMFVAR' then
-    for _,dir in next,stringexplode(texmfvar,os.type == "windows" and ";" or ":") do
+    for _,dir in next, texmfvar:explode(os.type == "windows" and ";" or ":") do
       if not lfsisdir(dir) then
         mk_full_path(dir)
       end
@@ -475,7 +450,7 @@ end
 if not outputdir then
   outputdir = "."
   for _,v in ipairs(arg) do
-    local t = stringmatch(v,"%-output%-directory=(.+)")
+    local t = v:match("%-output%-directory=(.+)")
     if t then
       outputdir = t
       break
@@ -501,43 +476,19 @@ function luamplib.getcachedir(dir)
 end
 
 local noneedtoreplace = {
-  ["boxes.mp"] = true,
-  --  ["format.mp"] = true,
-  ["graph.mp"] = true,
-  ["marith.mp"] = true,
-  ["mfplain.mp"] = true,
-  ["mpost.mp"] = true,
-  ["plain.mp"] = true,
-  ["rboxes.mp"] = true,
-  ["sarith.mp"] = true,
-  ["string.mp"] = true,
-  ["TEX.mp"] = true,
-  ["metafun.mp"] = true,
-  ["metafun.mpiv"] = true,
-  ["mp-abck.mpiv"] = true,
-  ["mp-apos.mpiv"] = true,
-  ["mp-asnc.mpiv"] = true,
-  ["mp-bare.mpiv"] = true,
-  ["mp-base.mpiv"] = true,
-  ["mp-butt.mpiv"] = true,
-  ["mp-char.mpiv"] = true,
-  ["mp-chem.mpiv"] = true,
-  ["mp-core.mpiv"] = true,
-  ["mp-crop.mpiv"] = true,
-  ["mp-figs.mpiv"] = true,
-  ["mp-form.mpiv"] = true,
-  ["mp-func.mpiv"] = true,
-  ["mp-grap.mpiv"] = true,
-  ["mp-grid.mpiv"] = true,
-  ["mp-grph.mpiv"] = true,
-  ["mp-idea.mpiv"] = true,
-  ["mp-luas.mpiv"] = true,
-  ["mp-mlib.mpiv"] = true,
-  ["mp-node.mpiv"] = true,
-  ["mp-page.mpiv"] = true,
-  ["mp-shap.mpiv"] = true,
-  ["mp-step.mpiv"] = true,
-  ["mp-text.mpiv"] = true,
+  ["boxes.mp"] = true, --  ["format.mp"] = true,
+  ["graph.mp"] = true, ["marith.mp"] = true, ["mfplain.mp"] = true,
+  ["mpost.mp"] = true, ["plain.mp"] = true, ["rboxes.mp"] = true,
+  ["sarith.mp"] = true, ["string.mp"] = true, -- ["TEX.mp"] = true,
+  ["metafun.mp"] = true, ["metafun.mpiv"] = true, ["mp-abck.mpiv"] = true,
+  ["mp-apos.mpiv"] = true, ["mp-asnc.mpiv"] = true, ["mp-bare.mpiv"] = true,
+  ["mp-base.mpiv"] = true, ["mp-blob.mpiv"] = true, ["mp-butt.mpiv"] = true,
+  ["mp-char.mpiv"] = true, ["mp-chem.mpiv"] = true, ["mp-core.mpiv"] = true,
+  ["mp-crop.mpiv"] = true, ["mp-figs.mpiv"] = true, ["mp-form.mpiv"] = true,
+  ["mp-func.mpiv"] = true, ["mp-grap.mpiv"] = true, ["mp-grid.mpiv"] = true,
+  ["mp-grph.mpiv"] = true, ["mp-idea.mpiv"] = true, ["mp-luas.mpiv"] = true,
+  ["mp-mlib.mpiv"] = true, ["mp-node.mpiv"] = true, ["mp-page.mpiv"] = true,
+  ["mp-shap.mpiv"] = true, ["mp-step.mpiv"] = true, ["mp-text.mpiv"] = true,
   ["mp-tool.mpiv"] = true,
 }
 luamplib.noneedtoreplace = noneedtoreplace
@@ -560,25 +511,10 @@ local function replaceformatmp(file,newfile,ofmodify)
   return newfile
 end
 
-local esctex  = "!!!T!!!E!!!X!!!"
-local esclbr  = "!!!!!LEFTBRCE!!!!!"
-local escrbr  = "!!!!!RGHTBRCE!!!!!"
-local escpcnt = "!!!!!PERCENT!!!!!"
-local eschash = "!!!!!HASH!!!!!"
-local begname = "%f[A-Z_a-z]"
-local endname = "%f[^A-Z_a-z]"
-
-local btex_etex        = begname.."btex"..endname.."%s*(.-)%s*"..begname.."etex"..endname
-local verbatimtex_etex = begname.."verbatimtex"..endname.."%s*(.-)%s*"..begname.."etex"..endname
-
-local function protecttexcontents(str)
-  return str:gsub("\\%%", "\\"..escpcnt)
-            :gsub("%%.-\n", "")
-            :gsub("%%.-$",  "")
-            :gsub('"', '"&ditto&"')
-            :gsub("\n%s*", " ")
-            :gsub(escpcnt, "%%")
-end
+local name_b = "%f[A-Z_a-z]"
+local name_e = "%f[^A-Z_a-z]"
+local btex_etex = name_b.."btex"..name_e.."%s*(.-)%s*"..name_b.."etex"..name_e
+local verbatimtex_etex = name_b.."verbatimtex"..name_e.."%s*(.-)%s*"..name_b.."etex"..name_e
 
 local function replaceinputmpfile (name,file)
   local ofmodify = lfsattributes(file,"modification")
@@ -588,10 +524,12 @@ local function replaceinputmpfile (name,file)
   newfile = cachedir .."/luamplib_input_"..newfile
   if newfile and luamplibtime then
     local nf = lfsattributes(newfile)
-    if nf and nf.mode == "file" and ofmodify == nf.modification and luamplibtime < nf.access then
+    if nf and nf.mode == "file" and
+      ofmodify == nf.modification and luamplibtime < nf.access then
       return nf.size == 0 and file or newfile
     end
   end
+
   if name == "format.mp" then return replaceformatmp(file,newfile,ofmodify) end
 
   local fh = ioopen(file,"r")
@@ -599,21 +537,10 @@ local function replaceinputmpfile (name,file)
   local data = fh:read("*all"); fh:close()
 
   local count,cnt = 0,0
-
-  data = data:gsub("\"[^\n]-\"", function(str)
-    return str:gsub("([bem])tex"..endname,"%1"..esctex)
-  end)
-
-  data, cnt = data:gsub(btex_etex, function(str)
-    return format("rawtextext(\"%s\")",protecttexcontents(str))
-  end)
+  data, cnt = data:gsub(btex_etex, "btex %1 etex ") -- space
   count = count + cnt
-  data, cnt = data:gsub(verbatimtex_etex, "")
+  data, cnt = data:gsub(verbatimtex_etex, "verbatimtex %1 etex;") -- semicolon
   count = count + cnt
-
-  data = data:gsub("\"[^\n]-\"", function(str) -- restore string btex .. etex
-    return str:gsub("([bem])"..esctex, "%1tex")
-  end)
 
   if count == 0 then
     noneedtoreplace[name] = true
@@ -624,20 +551,13 @@ local function replaceinputmpfile (name,file)
     end
     return file
   end
+
   fh = ioopen(newfile,"w")
   if not fh then return file end
   fh:write(data); fh:close()
   lfstouch(newfile,currenttime,ofmodify)
   return newfile
 end
-
-local randomseed = nil
-%    \end{macrocode}
-%      As the finder function for |mplib|, use the |kpse| library and
-%      make it behave like as if MetaPost was used (or almost, since the engine
-%      name is not set this way---not sure if this is a problem).
-%
-%    \begin{macrocode}
 
 local mpkpse = kpse.new(arg[0], "mpost")
 
@@ -658,129 +578,34 @@ local function finder(name, mode, ftype)
       end
       return replaceinputmpfile(name,file)
     end
-    return mpkpse:find_file(name,stringmatch(name,"[a-zA-Z]+$"))
+    return mpkpse:find_file(name, name:match("[a-zA-Z]+$"))
   end
 end
 luamplib.finder = finder
-
-%    \end{macrocode}
-% The rest of this module is not documented. More info can be found in the
-% \LuaTeX{} manual, articles in user group journals and the files that
-% ship with \ConTeXt.
-%
-%    \begin{macrocode}
 
 function luamplib.resetlastlog()
   luamplib.lastlog = ""
 end
 
-%    \end{macrocode}
-% Below included is section that defines fallbacks for older
-% versions of mplib.
-%
-%    \begin{macrocode}
-local mplibone = tonumber(mplib.version()) <= 1.50
-
-if mplibone then
-
-  luamplib.make = luamplib.make or function(name,mem_name,dump)
-    local t = os.clock()
-    local mpx = mplib.new {
-      ini_version = true,
-      find_file = luamplib.finder,
-      job_name = stripsuffix(name)
-    }
-    mpx:execute(format("input %s ;",name))
-    if dump then
-      mpx:execute("dump ;")
-      info("format %s made and dumped for %s in %0.3f seconds",mem_name,name,os.clock()-t)
-    else
-      info("%s read in %0.3f seconds",name,os.clock()-t)
-    end
-    return mpx
-  end
-
-  function luamplib.load(name)
-    local mem_name = replacesuffix(name,"mem")
-    local mpx = mplib.new {
-      ini_version = false,
-      mem_name = mem_name,
-      find_file = luamplib.finder
-    }
-    if not mpx and type(luamplib.make) == "function" then
-      -- when i have time i'll locate the format and dump
-      mpx = luamplib.make(name,mem_name)
-    end
-    if mpx then
-      info("using format %s",mem_name,false)
-      return mpx, nil
-    else
-      return nil, { status = 99, error = "out of memory or invalid format" }
-    end
-  end
-
-else
-
-%    \end{macrocode}
-% These are the versions called with sufficiently recent mplib.
-%
-%    \begin{macrocode}
-  local preamble = [[
-    boolean mplib ; mplib := true ;
-    let dump = endinput ;
-    let normalfontsize = fontsize;
-    input %s ;
-  ]]
-
-  luamplib.make = luamplib.make or function()
-  end
-
-  function luamplib.load(name,verbatim)
-    local mpx = mplib.new {
-      ini_version = true,
-      find_file = luamplib.finder,
-%    \end{macrocode}
-%    Provides |numbersystem| option since v2.4. Default value |"scaled"|
-%    can be changed by declaring |\mplibnumbersystem{double}|.
-%    See \url{https://github.com/lualatex/luamplib/issues/21}.
-%    \begin{macrocode}
-      math_mode = luamplib.numbersystem,
-      random_seed = randomseed,
-    }
-%    \end{macrocode}
-%     Append our own preamble to the preamble above.
-%    \begin{macrocode}
-    local preamble = preamble .. (verbatim and "" or luamplib.mplibcodepreamble)
-    if luamplib.textextlabel then
-      preamble = preamble .. (verbatim and "" or luamplib.textextlabelpreamble)
-    end
-    local result
-    if not mpx then
-      result = { status = 99, error = "out of memory"}
-    else
-      result = mpx:execute(format(preamble, replacesuffix(name,"mp")))
-    end
-    luamplib.reporterror(result)
-    return mpx, result
-  end
-
+if tonumber(mplib.version()) <= 1.50 then
+  err("luamplib no longer supports mplib v1.50 or lower")
 end
 
-local currentformat = "plain"
+local preamble = [[
+  boolean mplib ; mplib := true ;
+  let dump = endinput ;
+  let normalfontsize = fontsize;
+  input %s ;
+]]
 
-local function setformat (name) --- used in .sty
-  currentformat = name
-end
-luamplib.setformat = setformat
-
-
-luamplib.reporterror = function (result)
+local function reporterror (result)
   if not result then
     err("no result object returned")
   else
     local t, e, l = result.term, result.error, result.log
-    local log = stringgsub(t or l or "no-term","^%s+","\n")
-    luamplib.lastlog = luamplib.lastlog .. "\n " .. (l or t or "no-log")
+    local log = t or l or "no-term"
+    log = log:gsub("^%s+","\n")
+    luamplib.lastlog = luamplib.lastlog .. "\n" .. (l or t or "no-log")
     if result.status > 0 then
       warn("%s",log)
       if result.status > 1 then
@@ -791,23 +616,50 @@ luamplib.reporterror = function (result)
   end
 end
 
-local function process_indeed (mpx, data, indeed)
+local function luamplibload (name)
+  local mpx = mplib.new {
+    ini_version = true,
+    find_file   = luamplib.finder,
+    make_text   = luamplib.maketext,
+    run_script  = luamplib.runscript,
+    math_mode   = luamplib.numbersystem,
+    extensions  = 1,
+  }
+  local preamble = preamble .. luamplib.mplibcodepreamble
+  if luamplib.legacy_verbatimtex then
+    preamble = preamble .. luamplib.legacyverbatimtexpreamble
+  end
+  if luamplib.textextlabel then
+    preamble = preamble .. luamplib.textextlabelpreamble
+  end
+  local result
+  if not mpx then
+    result = { status = 99, error = "out of memory"}
+  else
+    result = mpx:execute(format(preamble, replacesuffix(name,"mp")))
+  end
+  reporterror(result)
+  return mpx, result
+end
+
+local currentformat = "plain"
+
+local function setformat (name)
+  currentformat = name
+end
+luamplib.setformat = setformat
+
+local function process_indeed (mpx, data)
   local converted, result = false, {}
   if mpx and data then
     result = mpx:execute(data)
-    local log = luamplib.reporterror(result)
-    if indeed and log then
+    local log = reporterror(result)
+    if log then
       if luamplib.showlog then
         info("%s",luamplib.lastlog)
         luamplib.resetlastlog()
       elseif result.fig then
-%    \end{macrocode}
-%    v2.6.1: now luamplib does not disregard |show| command,
-%    even when |luamplib.showlog| is false.  Incidentally,
-%    it does not raise error, but just prints a warning,
-%    even if output has no figure.
-%    \begin{macrocode}
-        if stringfind(log,"\n>>") then info("%s",log) end
+        if log:find("\n>>") then info("%s",log) end
         converted = luamplib.convert(result)
       else
         info("%s",log)
@@ -820,30 +672,348 @@ local function process_indeed (mpx, data, indeed)
   return converted, result
 end
 
-%    \end{macrocode}
-%     v2.9 has introduced the concept of `code inherit'
-%    \begin{macrocode}
 luamplib.codeinherit = false
 local mplibinstances = {}
-local process = function (data,indeed,verbatim)
-%    \end{macrocode}
-%     workaround issue \#70
-%    \begin{macrocode}
-  if not stringfind(data, begname.."beginfig%s*%([%+%-%s]*%d[%.%d%s]*%)") then
+
+local function process (data)
+  if not data:find(name_b.."beginfig%s*%([%+%-%s]*%d[%.%d%s]*%)") then
     data = data .. "beginfig(-1);endfig;"
   end
-  local standalone, firstpass = not luamplib.codeinherit, not indeed
+  local standalone = not luamplib.codeinherit
   local currfmt = currentformat .. (luamplib.numbersystem or "scaled")
-  currfmt = firstpass and currfmt or (currfmt.."2")
+    .. tostring(luamplib.textextlabel) .. tostring(luamplib.legacy_verbatimtex)
   local mpx = mplibinstances[currfmt]
+  if mpx and standalone then
+    mpx:finish()
+  end
   if standalone or not mpx then
-    randomseed = firstpass and math.random(65535) or randomseed
-    mpx = luamplib.load(currentformat,verbatim)
+    mpx = luamplibload(currentformat)
     mplibinstances[currfmt] = mpx
   end
-  return process_indeed(mpx, data, indeed)
+  return process_indeed(mpx, data)
 end
-luamplib.process = process
+
+local catlatex = luatexbase.registernumber("catcodetable@latex")
+local catat11  = luatexbase.registernumber("catcodetable@atletter")
+
+local function run_tex_code_no_use (str, cat)
+  cat = cat or catlatex
+  texscantoks("mplibtmptoks", cat, str)
+  texruntoks("mplibtmptoks")
+end
+
+local function run_tex_code (str, cat)
+  cat = cat or catlatex
+  texruntoks(function() texsprint(cat, str) end)
+end
+
+local tex_box_id = 2047
+local factor = 65536*(7227/7200)
+
+local function process_tex_text (str)
+  if str then
+    tex_box_id = tex_box_id + 1
+    local global = luamplib.globaltextext and "\\global" or ""
+    run_tex_code(format("%s\\setbox%i\\hbox{%s}", global, tex_box_id, str))
+    local box = texgetbox(tex_box_id)
+    local wd  = box.width  / factor
+    local ht  = box.height / factor
+    local dp  = box.depth  / factor
+    return format("image(addto currentpicture doublepath unitsquare "..
+    "xscaled %f yscaled %f shifted (0,-%f) "..
+    "withprescript \"mplibtexboxid=%i:%f:%f\")",
+    wd, ht+dp, dp, tex_box_id, wd, ht+dp)
+  end
+  return ""
+end
+
+local function process_color (str)
+  if str then
+    if not str:find("{.-}") then
+      str = format("{%s}",str)
+    end
+    run_tex_code(format(
+      "\\def\\set@color{\\toks0\\expandafter{\\current@color}}\\color %s", str),
+      catat11)
+    return format("1 withprescript \"MPlibOverrideColor=%s\"", texgettoks(0))
+  end
+  return ""
+end
+
+local function process_dimen (str)
+  if str then
+    str = str:gsub("{(.+)}","%1")
+    run_tex_code(format("\\toks0\\expandafter{\\the\\dimexpr %s\\relax}", str))
+    return format("begingroup %s endgroup", texgettoks(0))
+  end
+  return ""
+end
+
+local function process_verbatimtex_text (str)
+  if str then
+    run_tex_code(str)
+  end
+  return ""
+end
+
+-- for legacy verbatimtex process
+local tex_code_pre_mplib = {}
+luamplib.figid = 1
+luamplib.in_the_fig = false
+
+local function legacy_mplibcode_reset ()
+  tex_code_pre_mplib = {}
+  luamplib.figid = 1
+end
+
+local function process_verbatimtex_prefig (str)
+  if str then
+    tex_code_pre_mplib[luamplib.figid] = str
+  end
+  return ""
+end
+
+local function process_verbatimtex_infig (str)
+  if str then
+    return format("special \"postmplibverbtex=%s\";", str)
+  end
+  return ""
+end
+
+local runscript_funcs = {
+  luamplibtext    = process_tex_text,
+  luamplibcolor   = process_color,
+  luamplibdimen   = process_dimen,
+  luamplibprefig  = process_verbatimtex_prefig,
+  luamplibinfig   = process_verbatimtex_infig,
+  luamplibverbtex = process_verbatimtex_text,
+}
+
+local function mpprint(buffer,...)
+  for i=1,select("#",...) do
+    local value = select(i,...)
+    if value ~= nil then
+      local t = type(value)
+      if t == "number" then
+        buffer[#buffer+1] = format("%.16f",value)
+      elseif t == "string" then
+        buffer[#buffer+1] = value
+      elseif t == "table" then
+        buffer[#buffer+1] = "(" .. concat(value,",") .. ")"
+      else -- boolean or whatever
+        buffer[#buffer+1] = tostring(value)
+      end
+    end
+  end
+end
+
+-- for metafun
+mp = mp or {}
+local mp = mp
+mp.mf_path_reset = mp.mf_path_reset or function() end
+mp.mf_finish_saving_data = mp.mf_finish_saving_data or function() end
+LUATEXFUNCTIONALITY = LUATEXFUNCTIONALITY or 0
+
+function luamplib.runscript (code)
+  local id, str = code:match("(.-){(.+)}")
+  if id and str and str ~= "" then
+    local f = runscript_funcs[id]
+    if f then
+      local t = f(str)
+      if t then return t end
+    end
+  end
+  local f = loadstring(code)
+  if type(f) == "function" then
+    local buffer = {}
+    function mp.print(...)
+      mpprint(buffer,...)
+    end
+    f()
+    return tableconcat(buffer,"")
+  end
+  return ""
+end
+
+local function protecttexcontents (str)
+  return str:gsub("\\%%", "\0PerCent\0")
+            :gsub("%%.-\n", "")
+            :gsub("%%.-$",  "")
+            :gsub("%zPerCent%z", "\\%%")
+            :gsub("%s+", " ")
+end
+
+luamplib.legacy_verbatimtex = true
+
+function luamplib.maketext (str, what)
+  if str and str ~= "" then
+    str = protecttexcontents(str)
+    if what == 1 then
+      if not str:find("\\documentclass"..name_e) and
+         not str:find("\\begin%s*{document}") and
+         not str:find("\\documentstyle"..name_e) and
+         not str:find("\\usepackage"..name_e) then
+        if luamplib.legacy_verbatimtex then
+          if luamplib.in_the_fig then
+            return process_verbatimtex_infig(str)
+          else
+            return process_verbatimtex_prefig(str)
+          end
+        else
+          return process_verbatimtex_text(str)
+        end
+      end
+    else
+      return process_tex_text(str)
+    end
+  end
+  return ""
+end
+
+local mplibcodepreamble = [[
+texscriptmode := 2;
+def rawtextext (expr t) = runscript("luamplibtext{"&t&"}") enddef;
+def mplibcolor (expr t) = runscript("luamplibcolor{"&t&"}") enddef;
+def mplibdimen (expr t) = runscript("luamplibdimen{"&t&"}") enddef;
+def VerbatimTeX (expr t) = runscript("luamplibverbtex{"&t&"}") enddef;
+if known context_mlib:
+  defaultfont := "cmtt10";
+  let infont = normalinfont;
+  let fontsize = normalfontsize;
+  vardef thelabel@#(expr p,z) =
+    if string p :
+      thelabel@#(p infont defaultfont scaled defaultscale,z)
+    else :
+      p shifted (z + labeloffset*mfun_laboff@# -
+        (mfun_labxf@#*lrcorner p + mfun_labyf@#*ulcorner p +
+        (1-mfun_labxf@#-mfun_labyf@#)*llcorner p))
+    fi
+  enddef;
+  def graphictext primary filename =
+    if (readfrom filename = EOF):
+      errmessage "Please prepare '"&filename&"' in advance with"&
+      " 'pstoedit -ssp -dt -f mpost yourfile.ps "&filename&"'";
+    fi
+    closefrom filename;
+    def data_mpy_file = filename enddef;
+    mfun_do_graphic_text (filename)
+  enddef;
+else:
+  vardef textext@# (text t) = rawtextext (t) enddef;
+fi
+def externalfigure primary filename =
+  draw rawtextext("\includegraphics{"& filename &"}")
+enddef;
+def TEX = textext enddef;
+]]
+luamplib.mplibcodepreamble = mplibcodepreamble
+
+local legacyverbatimtexpreamble = [[
+def specialVerbatimTeX (text t) = runscript("luamplibprefig{"&t&"}") enddef;
+def normalVerbatimTeX  (text t) = runscript("luamplibinfig{"&t&"}") enddef;
+let VerbatimTeX = specialVerbatimTeX;
+extra_beginfig := extra_beginfig & " let VerbatimTeX = normalVerbatimTeX;"&
+  "runscript(" &ditto& "luamplib.in_the_fig=true" &ditto& ");";
+extra_endfig := extra_endfig & " let VerbatimTeX = specialVerbatimTeX;"&
+  "runscript(" &ditto&
+  "luamplib.in_the_fig=false luamplib.figid=luamplib.figid+1" &ditto& ");";
+]]
+luamplib.legacyverbatimtexpreamble = legacyverbatimtexpreamble
+
+local textextlabelpreamble = [[
+primarydef s infont f = rawtextext(s) enddef;
+def fontsize expr f =
+  begingroup
+  save size,pic; numeric size; picture pic;
+  pic := rawtextext("\hskip\pdffontsize\font");
+  size := xpart urcorner pic - xpart llcorner pic;
+  if size = 0: 10pt else: size fi
+  endgroup
+enddef;
+]]
+luamplib.textextlabelpreamble = textextlabelpreamble
+
+luamplib.verbatiminput = false
+
+local function protect_expansion (str)
+  if str then
+    str = str:gsub("\\","\1Control\1")
+             :gsub("%%","\1Comment\1")
+             :gsub("#", "\1HashSign\1")
+             :gsub("{", "\1LBrace\1")
+             :gsub("}", "\1RBrace\1")
+    return format("\\unexpanded{%s}",str)
+  end
+end
+
+local function unprotect_expansion (str)
+  if str then
+    return str:gsub("\1Control\1", "\\")
+              :gsub("\1Comment\1", "%%")
+              :gsub("\1HashSign\1","#")
+              :gsub("\1LBrace\1",  "{")
+              :gsub("\1RBrace\1",  "}")
+  end
+end
+
+local function process_mplibcode (data)
+  legacy_mplibcode_reset()
+
+  local everymplib    = texgettoks('everymplibtoks')    or ''
+  local everyendmplib = texgettoks('everyendmplibtoks') or ''
+  data = format("\n%s\n%s\n%s\n",everymplib, data, everyendmplib)
+  data = data:gsub("\r","\n")
+
+  data = data:gsub("\\mpcolor%s+(.-%b{})","mplibcolor(\"%1\")")
+
+  data = data:gsub(btex_etex, function(str)
+    return format("btex %s etex ", -- space
+      luamplib.verbatiminput and str or protect_expansion(str))
+  end)
+  data = data:gsub(verbatimtex_etex, function(str)
+    return format("verbatimtex %s etex;", -- semicolon
+      luamplib.verbatiminput and str or protect_expansion(str))
+  end)
+
+  if not luamplib.verbatiminput then
+    data = data:gsub("\".-\"", protect_expansion)
+    data = data:gsub("%%.-\n","")
+    run_tex_code(format("\\toks0\\expanded{{%s}}",data))
+    data = texgettoks(0)
+    data = data:gsub("##", "#")
+    data = data:gsub("\".-\"", unprotect_expansion)
+    data = data:gsub(btex_etex, function(str)
+      return format("btex %s etex", unprotect_expansion(str))
+    end)
+    data = data:gsub(verbatimtex_etex, function(str)
+      return format("verbatimtex %s etex", unprotect_expansion(str))
+    end)
+  end
+
+  process(data)
+end
+luamplib.process_mplibcode = process_mplibcode
+
+local further_split_keys = {
+  ["mplibtexboxid"] = true,
+  ["sh_color_a"]    = true,
+  ["sh_color_b"]    = true,
+}
+
+local function script2table(s)
+  local t = {}
+  for _,i in ipairs(s:explode("\13+")) do
+    local k,v = i:match("(.-)=(.*)") -- v may contain = or empty.
+    if k and v and k ~= "" then
+      if further_split_keys[k] then
+        t[k] = v:explode(":")
+      else
+        t[k] = v
+      end
+    end
+  end
+  return t
+end
 
 local function getobjects(result,figure,f)
   return figure:objects()
@@ -856,9 +1026,6 @@ end
 luamplib.convert = convert
 
 local function pdf_startfigure(n,llx,lly,urx,ury)
-%    \end{macrocode}
-%     The following line has been slightly modified by Kim.
-%    \begin{macrocode}
   texsprint(format("\\mplibstarttoPDF{%f}{%f}{%f}{%f}",llx,lly,urx,ury))
 end
 
@@ -866,26 +1033,17 @@ local function pdf_stopfigure()
   texsprint("\\mplibstoptoPDF")
 end
 
-%    \end{macrocode}
-%    |tex.tprint| and catcode regime -2, as sometimes |#| gets doubled
-%    in the argument of pdfliteral. --- modified by Kim
-%    \begin{macrocode}
 local function pdf_literalcode(fmt,...) -- table
   textprint({"\\mplibtoPDF{"},{-2,format(fmt,...)},{"}"})
 end
-luamplib.pdf_literalcode = pdf_literalcode
 
 local function pdf_textfigure(font,size,text,width,height,depth)
-%    \end{macrocode}
-%     The following three lines have been modified by Kim.
-%    \begin{macrocode}
   -- if text == "" then text = "\0" end -- char(0) has gone
   text = text:gsub(".",function(c)
     return format("\\hbox{\\char%i}",string.byte(c)) -- kerning happens in metapost
   end)
   texsprint(format("\\mplibtextext{%s}{%f}{%s}{%s}{%f}",font,size,text,0,-( 7200/ 7227)/65536*depth))
 end
-luamplib.pdf_textfigure = pdf_textfigure
 
 local bend_tolerance = 131/65536
 
@@ -972,254 +1130,6 @@ local function flushconcatpath(path,open)
   end
 end
 
-%    \end{macrocode}
-%     Below code has been contributed by Dohyun Kim.
-%     It implements |btex| / |etex| functions.
-%
-%     v2.1: |textext()| is now available, which is equivalent to |TEX()| macro from TEX.mp.
-%           |TEX()| is synonym of |textext()| unless TEX.mp is loaded.
-%
-%     v2.2: Transparency and Shading
-%
-%     v2.3: \cs{everymplib}, \cs{everyendmplib},
-%           and allows naked \TeX\ commands.
-%    \begin{macrocode}
-local further_split_keys = {
-  ["MPlibTEXboxID"] = true,
-  ["sh_color_a"]    = true,
-  ["sh_color_b"]    = true,
-}
-
-local function script2table(s)
-  local t = {}
-  for _,i in ipairs(stringexplode(s,"\13+")) do
-    local k,v = stringmatch(i,"(.-)=(.*)") -- v may contain = or empty.
-    if k and v and k ~= "" then
-      if further_split_keys[k] then
-        t[k] = stringexplode(v,":")
-      else
-        t[k] = v
-      end
-    end
-  end
-  return t
-end
-
-local mplibcodepreamble = [[
-vardef rawtextext (expr t) =
-  if unknown TEXBOX_:
-    image( special "MPlibmkTEXbox="&t;
-      addto currentpicture doublepath unitsquare; )
-  else:
-    TEXBOX_ := TEXBOX_ + 1;
-    if known TEXBOX_wd_[TEXBOX_]:
-      image ( addto currentpicture doublepath unitsquare
-        xscaled TEXBOX_wd_[TEXBOX_]
-        yscaled (TEXBOX_ht_[TEXBOX_] + TEXBOX_dp_[TEXBOX_])
-        shifted (0, -TEXBOX_dp_[TEXBOX_])
-        withprescript "MPlibTEXboxID=" &
-          decimal TEXBOX_ & ":" &
-          decimal TEXBOX_wd_[TEXBOX_] & ":" &
-          decimal(TEXBOX_ht_[TEXBOX_]+TEXBOX_dp_[TEXBOX_]); )
-    else:
-      image( special "MPlibTEXError=1"; )
-    fi
-  fi
-enddef;
-if known context_mlib:
-  defaultfont := "cmtt10";
-  let infont = normalinfont;
-  let fontsize = normalfontsize;
-  vardef thelabel@#(expr p,z) =
-    if string p :
-      thelabel@#(p infont defaultfont scaled defaultscale,z)
-    else :
-      p shifted (z + labeloffset*mfun_laboff@# -
-        (mfun_labxf@#*lrcorner p + mfun_labyf@#*ulcorner p +
-        (1-mfun_labxf@#-mfun_labyf@#)*llcorner p))
-    fi
-  enddef;
-  def graphictext primary filename =
-    if (readfrom filename = EOF):
-      errmessage "Please prepare '"&filename&"' in advance with"&
-      " 'pstoedit -ssp -dt -f mpost yourfile.ps "&filename&"'";
-    fi
-    closefrom filename;
-    def data_mpy_file = filename enddef;
-    mfun_do_graphic_text (filename)
-  enddef;
-else:
-  vardef textext@# (text t) = rawtextext (t) enddef;
-fi
-def externalfigure primary filename =
-  draw rawtextext("\includegraphics{"& filename &"}")
-enddef;
-def TEX = textext enddef;
-def specialVerbatimTeX (text t) = special "MPlibVerbTeX="&t; enddef;
-def normalVerbatimTeX  (text t) = special "PostMPlibVerbTeX="&t; enddef;
-let VerbatimTeX = specialVerbatimTeX;
-extra_beginfig := extra_beginfig & " let VerbatimTeX = normalVerbatimTeX;" ;
-extra_endfig   := extra_endfig   & " let VerbatimTeX = specialVerbatimTeX;" ;
-]]
-luamplib.mplibcodepreamble = mplibcodepreamble
-
-local textextlabelpreamble = [[
-primarydef s infont f = rawtextext(s) enddef;
-def fontsize expr f =
-  begingroup
-  save size,pic; numeric size; picture pic;
-  pic := rawtextext("\hskip\pdffontsize\font");
-  size := xpart urcorner pic - xpart llcorner pic;
-  if size = 0: 10pt else: size fi
-  endgroup
-enddef;
-]]
-luamplib.textextlabelpreamble = textextlabelpreamble
-
-local TeX_code_t = {}
-local texboxnum = { 2047 }
-
-local function domakeTEXboxes (data)
-  local num = texboxnum[1]
-  texboxnum[2] = num
-  local global = luamplib.globaltextext and "\\global" or ""
-  if data and data.fig then
-    local figures = data.fig
-    for f=1, #figures do
-      TeX_code_t[f] = nil
-      local figure = figures[f]
-      local objects = getobjects(data,figure,f)
-      if objects then
-        for o=1,#objects do
-          local object    = objects[o]
-          local prescript = object.prescript
-          prescript = prescript and script2table(prescript)
-          local str = prescript and prescript.MPlibmkTEXbox
-          if str then
-            num = num + 1
-            texsprint(format("%s\\setbox%i\\hbox{%s}", global, num, str))
-          end
-%    \end{macrocode}
-%     |verbatimtex ... etex| before |beginfig()| is not ignored,
-%     but the \TeX\ code inbetween is inserted before the mplib box.
-%    \begin{macrocode}
-          local texcode = prescript and prescript.MPlibVerbTeX
-          if texcode and texcode ~= "" then
-            TeX_code_t[f] = texcode
-          end
-        end
-      end
-    end
-  end
-  if luamplib.globaltextext then
-    texboxnum[1] = num
-  end
-end
-
-local function protect_tex_text_common (data)
-  local everymplib    = texgettoks('everymplibtoks')    or ''
-  local everyendmplib = texgettoks('everyendmplibtoks') or ''
-  data = format("\n%s\n%s\n%s",everymplib, data, everyendmplib)
-  data = data:gsub("\r","\n")
-
-  data = data:gsub("\"[^\n]-\"", function(str)
-    return str:gsub("([bem])tex"..endname,"%1"..esctex)
-  end)
-
-  data = data:gsub(btex_etex, function(str)
-    return format("rawtextext(\"%s\")",protecttexcontents(str))
-  end)
-  data = data:gsub(verbatimtex_etex, function(str)
-    return format("VerbatimTeX(\"%s\")",protecttexcontents(str))
-  end)
-
-  return data
-end
-
-local function protecttextextVerbatim(data)
-  data = protect_tex_text_common(data)
-
-  data = data:gsub("\"[^\n]-\"", function(str) -- restore string btex .. etex
-    return str:gsub("([bem])"..esctex, "%1tex")
-  end)
-
-  local _,result = process(data, false)
-  domakeTEXboxes(result)
-  return data
-end
-
-luamplib.protecttextextVerbatim = protecttextextVerbatim
-
-luamplib.mpxcolors = {}
-
-local function protecttextext(data)
-  data = protect_tex_text_common(data)
-
-  data = data:gsub("\"[^\n]-\"", function(str)
-    str = str:gsub("([bem])"..esctex, "%1tex")
-             :gsub("%%", escpcnt)
-             :gsub("{",  esclbr)
-             :gsub("}",  escrbr)
-             :gsub("#",  eschash)
-    return format("\\detokenize{%s}",str)
-  end)
-
-  data = data:gsub("%%.-\n", "")
-
-  local grouplevel = tex.currentgrouplevel
-  luamplib.mpxcolors[grouplevel] = {}
-  data = data:gsub("\\mpcolor"..endname.."(.-){(.-)}", function(opt,str)
-    local cnt = #luamplib.mpxcolors[grouplevel] + 1
-    luamplib.mpxcolors[grouplevel][cnt] = format(
-      "\\expandafter\\mplibcolor\\csname mpxcolor%i:%i\\endcsname%s{%s}",
-      grouplevel,cnt,opt,str)
-    return format("\\csname mpxcolor%i:%i\\endcsname",grouplevel,cnt)
-  end)
-
-%    \end{macrocode}
-%    Next line to address bug \#55
-%    \begin{macrocode}
-  data = data:gsub("([^`\\])#","%1##")
-
-  texsprint(data)
-end
-
-luamplib.protecttextext = protecttextext
-
-local function makeTEXboxes (data)
-  data = data:gsub("##","#")
-             :gsub(escpcnt,"%%")
-             :gsub(esclbr,"{")
-             :gsub(escrbr,"}")
-             :gsub(eschash,"#")
-  local _,result = process(data, false)
-  domakeTEXboxes(result)
-  return data
-end
-
-luamplib.makeTEXboxes = makeTEXboxes
-
-local factor = 65536*(7227/7200)
-
-local function processwithTEXboxes (data)
-  if not data then return end
-  local num = texboxnum[2]
-  local prepreamble = format("TEXBOX_:=%i;\n",num)
-  while true do
-    num = num + 1
-    local box = texgetbox(num)
-    if not box then break end
-    prepreamble = format(
-      "%sTEXBOX_wd_[%i]:=%f;\nTEXBOX_ht_[%i]:=%f;\nTEXBOX_dp_[%i]:=%f;\n",
-      prepreamble,
-      num, box.width /factor,
-      num, box.height/factor,
-      num, box.depth /factor)
-  end
-  process(prepreamble .. data, true)
-end
-luamplib.processwithTEXboxes = processwithTEXboxes
-
 local pdfoutput = tonumber(texget("outputmode")) or tonumber(texget("pdfoutput"))
 local pdfmode = pdfoutput > 0
 
@@ -1238,8 +1148,8 @@ local function stop_pdf_code()
   end
 end
 
-local function putTEXboxes (object,prescript)
-  local box = prescript.MPlibTEXboxID
+local function put_tex_boxes (object,prescript)
+  local box = prescript.mplibtexboxid
   local n,tw,th = box[1],tonumber(box[2]),tonumber(box[3])
   if n and tw and th then
     local op = object.path
@@ -1263,9 +1173,6 @@ local function putTEXboxes (object,prescript)
   end
 end
 
-%    \end{macrocode}
-%    Transparency and Shading
-%    \begin{macrocode}
 local pdf_objs = {}
 local token, getpageres, setpageres = newtoken or token
 local pgf = { bye = "pgfutil@everybye", extgs = "pgf@sys@addpdfresource@extgs@plain" }
@@ -1377,7 +1284,7 @@ local function sh_pdfpageresources(shtype,domain,colorspace,colora,colorb,coordi
         shading_res[#shading_res+1] = res
       else
         local pageres = getpageres() or ""
-        if not stringfind(pageres,"/Shading<<.*>>") then
+        if not pageres:find("/Shading<<.*>>") then
           pageres = pageres.."/Shading<<>>"
         end
         pageres = pageres:gsub("/Shading<<","%1"..res)
@@ -1443,8 +1350,8 @@ local function do_preobj_color(object,prescript)
   local sh_type = prescript and prescript.sh_type
   if sh_type then
     local domain  = prescript.sh_domain
-    local centera = stringexplode(prescript.sh_center_a)
-    local centerb = stringexplode(prescript.sh_center_b)
+    local centera = prescript.sh_center_a:explode()
+    local centerb = prescript.sh_center_b:explode()
     for _,t in pairs({centera,centerb}) do
       for i,v in ipairs(t) do
         t[i] = format("%f",v)
@@ -1500,11 +1407,6 @@ local function do_postobj_color(tr,over,sh)
   end
 end
 
-%    \end{macrocode}
-%     End of |btex| -- |etex| and Transparency/Shading patch.
-%
-%    \begin{macrocode}
-
 local function flush(result,flusher)
   if result then
     local figures = result.fig
@@ -1513,25 +1415,17 @@ local function flush(result,flusher)
         info("flushing figure %s",f)
         local figure = figures[f]
         local objects = getobjects(result,figure,f)
-        local fignum = tonumber(stringmatch(figure:filename(),"([%d]+)$") or figure:charcode() or 0)
+        local fignum = tonumber(figure:filename():match("([%d]+)$") or figure:charcode() or 0)
         local miterlimit, linecap, linejoin, dashed = -1, -1, -1, false
         local bbox = figure:boundingbox()
         local llx, lly, urx, ury = bbox[1], bbox[2], bbox[3], bbox[4] -- faster than unpack
         if urx < llx then
-%    \end{macrocode}
-%    \textsf{luamplib} silently ignores this invalid figure for those codes
-%    that do not contain |beginfig ... endfig|. (issue \#70)
-%    \begin{macrocode}
           -- invalid
           -- pdf_startfigure(fignum,0,0,0,0)
           -- pdf_stopfigure()
         else
-%    \end{macrocode}
-%    Insert |verbatimtex| code before mplib box.
-%    And prepare for those codes that will be executed afterwards.
-%    \begin{macrocode}
-          if TeX_code_t[f] then
-            texsprint(TeX_code_t[f])
+          if tex_code_pre_mplib[f] then
+            texsprint(tex_code_pre_mplib[f])
           end
           local TeX_code_bot = {} -- PostVerbatimTeX
           pdf_startfigure(fignum,llx,lly,urx,ury)
@@ -1542,19 +1436,11 @@ local function flush(result,flusher)
             for o=1,#objects do
               local object        = objects[o]
               local objecttype    = object.type
-%    \end{macrocode}
-%     Change from \ConTeXt{} code: the following 7 lines are part of the
-%     |btex...etex| patch. Again, colors are processed at this stage.
-%     Also, we collect \TeX\ codes that will be executed after flushing.
-%
-%    \begin{macrocode}
               local prescript     = object.prescript
               prescript = prescript and script2table(prescript) -- prescript is now a table
               local tr_opaq,cr_over,shade_no = do_preobj_color(object,prescript)
-              if prescript and prescript.MPlibTEXboxID then
-                putTEXboxes(object,prescript)
-              elseif prescript and prescript.PostMPlibVerbTeX then
-                TeX_code_bot[#TeX_code_bot+1] = prescript.PostMPlibVerbTeX
+              if prescript and prescript.mplibtexboxid then
+                put_tex_boxes(object,prescript)
               elseif objecttype == "start_bounds" or objecttype == "stop_bounds" then
                 -- skip
               elseif objecttype == "start_clip" then
@@ -1566,9 +1452,8 @@ local function flush(result,flusher)
                 stop_pdf_code()
                 miterlimit, linecap, linejoin, dashed = -1, -1, -1, false
               elseif objecttype == "special" then
-                -- not supported
-                if prescript and prescript.MPlibTEXError then
-                  warn("textext() anomaly. Try disabling \\mplibtextextlabel.")
+                if prescript and prescript.postmplibverbtex then
+                  TeX_code_bot[#TeX_code_bot+1] = prescript.postmplibverbtex
                 end
               elseif objecttype == "text" then
                 local ot = object.transform -- 3,4,5,6,1,2
@@ -1577,9 +1462,6 @@ local function flush(result,flusher)
                 pdf_textfigure(object.font,object.dsize,object.text,object.width,object.height,object.depth)
                 stop_pdf_code()
               else
-%    \end{macrocode}
-%     Color stuffs are modified and moved to several lines above.
-%    \begin{macrocode}
                 local evenodd, collect, both = false, false, false
                 local postscript = object.postscript
                 if not object.istext then
@@ -1664,11 +1546,6 @@ local function flush(result,flusher)
                     else
                       flushnormalpath(path,open)
                     end
-%    \end{macrocode}
-%
-%     Change from \ConTeXt{} code: color stuff
-%
-%    \begin{macrocode}
                     if not shade_no then ----- conflict with shading
                       if objecttype == "fill" then
                         pdf_literalcode(evenodd and "h f*" or "h f")
@@ -1721,20 +1598,12 @@ local function flush(result,flusher)
                   end
                 end
               end
-%    \end{macrocode}
-%
-%     Added to \ConTeXt{} code: color stuff.
-%     And execute |verbatimtex| codes.
-%
-%    \begin{macrocode}
               do_postobj_color(tr_opaq,cr_over,shade_no)
             end
           end
           stop_pdf_code()
           pdf_stopfigure()
-          if #TeX_code_bot > 0 then
-            texsprint(TeX_code_bot)
-          end
+          if #TeX_code_bot > 0 then texsprint(TeX_code_bot) end
         end
       end
     end
@@ -1777,42 +1646,22 @@ luamplib.colorconverter = colorconverter
 \else
   \NeedsTeXFormat{LaTeX2e}
   \ProvidesPackage{luamplib}
-    [2018/09/27 v2.12.5 mplib package for LuaTeX]
+    [2019/03/20 v2.20.0 mplib package for LuaTeX]
   \ifx\newluafunction\@undefined
   \input ltluatex
   \fi
 \fi
-%    \end{macrocode}
-%
-%    Loading of lua code.
-%
-%    \begin{macrocode}
 \directlua{require("luamplib")}
-%    \end{macrocode}
-%
-% Support older formats
-%    \begin{macrocode}
 \ifx\scantextokens\undefined
   \let\scantextokens\luatexscantextokens
 \fi
 \ifx\pdfoutput\undefined
   \let\pdfoutput\outputmode
   \protected\def\pdfliteral{\pdfextension literal}
+  \def\pdffontsize{\dimexpr\pdffeedback fontsize\relax}
 \fi
-%    \end{macrocode}
 
-%
-%    Set the format for metapost.
-%
-%    \begin{macrocode}
 \def\mplibsetformat#1{\directlua{luamplib.setformat("#1")}}
-%    \end{macrocode}
-%
-%    \textsf{luamplib} works in both PDF and DVI mode,
-%    but only DVIPDFMx is supported currently among a number of DVI tools.
-%    So we output a warning.
-%
-%    \begin{macrocode}
 \ifnum\pdfoutput>0
   \let\mplibtoPDF\pdfliteral
 \else
@@ -1830,11 +1679,6 @@ luamplib.colorconverter = colorconverter
   \catcode`\#=12 \catcode`\^=12 \catcode`\~=12 \catcode`\_=12
   \catcode`\&=12 \catcode`\$=12 \catcode`\%=12 \catcode`\^^M=12 \endlinechar=10
 }
-%    \end{macrocode}
-%
-%    Make |btex...etex| box zero-metric.
-%
-%    \begin{macrocode}
 \def\mplibputtextbox#1{\vbox to 0pt{\vss\hbox to 0pt{\raise\dp#1\copy#1\hss}}}
 \newcount\mplibstartlineno
 \def\mplibpostmpcatcodes{%
@@ -1843,11 +1687,6 @@ luamplib.colorconverter = colorconverter
   \begingroup \mplibpostmpcatcodes \mplibdoreplacenewlinebr}
 \begingroup\lccode`\~=`\^^M \lowercase{\endgroup
   \def\mplibdoreplacenewlinebr#1^^J{\endgroup\scantextokens{{}#1~}}}
-%    \end{macrocode}
-%
-%    The Plain-specific stuff.
-%
-%    \begin{macrocode}
 \bgroup\expandafter\expandafter\expandafter\egroup
 \expandafter\ifx\csname selectfont\endcsname\relax
 \def\mplibreplacenewlinecs{%
@@ -1863,24 +1702,11 @@ luamplib.colorconverter = colorconverter
 }
 \long\def\mplibdocode#1\endmplibcode{%
   \endgroup
-  \ifdefined\mplibverbatimYes
-    \directlua{luamplib.tempdata\the\currentgrouplevel=luamplib.protecttextextVerbatim([===[\detokenize{#1}]===])}%
-    \directlua{luamplib.processwithTEXboxes(luamplib.tempdata\the\currentgrouplevel)}%
-  \else
-    \edef\mplibtemp{\directlua{luamplib.protecttextext([===[\unexpanded{#1}]===])}}%
-    \directlua{ tex.sprint(luamplib.mpxcolors[\the\currentgrouplevel]) }%
-    \directlua{luamplib.tempdata\the\currentgrouplevel=luamplib.makeTEXboxes([===[\mplibtemp]===])}%
-    \directlua{luamplib.processwithTEXboxes(luamplib.tempdata\the\currentgrouplevel)}%
-  \fi
+  \directlua{luamplib.process_mplibcode([===[\unexpanded{#1}]===])}%
   \endgroup
   \ifnum\mplibstartlineno<\inputlineno\expandafter\mplibreplacenewlinecs\fi
 }
 \else
-%    \end{macrocode}
-%
-%    The \LaTeX-specific parts: a new environment.
-%
-%    \begin{macrocode}
 \newenvironment{mplibcode}{%
   \global\mplibstartlineno\inputlineno
   \toks@{}\ltxdomplibcode
@@ -1894,16 +1720,9 @@ luamplib.colorconverter = colorconverter
 \long\def\ltxdomplibcodeindeed#1\end#2{%
   \endgroup
   \toks@\expandafter{\the\toks@#1}%
-  \def\mplibtemp@a{#2}\ifx\mplib@mplibcode\mplibtemp@a
-    \ifdefined\mplibverbatimYes
-      \directlua{luamplib.tempdata\the\currentgrouplevel=luamplib.protecttextextVerbatim([===[\the\toks@]===])}%
-      \directlua{luamplib.processwithTEXboxes(luamplib.tempdata\the\currentgrouplevel)}%
-    \else
-      \edef\mplibtemp{\directlua{luamplib.protecttextext([===[\the\toks@]===])}}%
-      \directlua{ tex.sprint(luamplib.mpxcolors[\the\currentgrouplevel]) }%
-      \directlua{luamplib.tempdata\the\currentgrouplevel=luamplib.makeTEXboxes([===[\mplibtemp]===])}%
-      \directlua{luamplib.processwithTEXboxes(luamplib.tempdata\the\currentgrouplevel)}%
-    \fi
+  \def\mplibtemp@a{#2}%
+  \ifx\mplib@mplibcode\mplibtemp@a
+    \directlua{luamplib.process_mplibcode([===[\the\toks@]===])}%
     \end{mplibcode}%
     \ifnum\mplibstartlineno<\inputlineno
       \expandafter\expandafter\expandafter\mplibreplacenewlinebr
@@ -1913,22 +1732,27 @@ luamplib.colorconverter = colorconverter
   \fi
 }
 \fi
+\def\mpliblegacybehavior#1{%
+  \begingroup
+  \def\mplibtempa{#1}\def\mplibtempb{enable}%
+  \expandafter\endgroup
+  \ifx\mplibtempa\mplibtempb
+    \directlua{luamplib.legacy_verbatimtex = true}%
+  \else
+    \directlua{luamplib.legacy_verbatimtex = false}%
+  \fi
+}
 \def\mplibverbatim#1{%
   \begingroup
   \def\mplibtempa{#1}\def\mplibtempb{enable}%
   \expandafter\endgroup
   \ifx\mplibtempa\mplibtempb
-    \let\mplibverbatimYes\relax
+    \directlua{luamplib.verbatiminput = true}%
   \else
-    \let\mplibverbatimYes\undefined
+    \directlua{luamplib.verbatiminput = false}%
   \fi
 }
-%    \end{macrocode}
-%
-%    \cs{everymplib} \& \cs{everyendmplib}: macros redefining
-%    \cs{everymplibtoks} \& \cs{everyendmplibtoks} respectively
-%
-%    \begin{macrocode}
+\newtoks\mplibtmptoks
 \newtoks\everymplibtoks
 \newtoks\everyendmplibtoks
 \protected\def\everymplib{%
@@ -1954,17 +1778,11 @@ luamplib.colorconverter = colorconverter
   \ifnum\mplibstartlineno<\inputlineno\expandafter\mplibreplacenewlinebr\fi
 }
 \def\mpdim#1{ begingroup \the\dimexpr #1\relax\space endgroup } % gmp.sty
-%    \end{macrocode}
-%
-%     Support color/xcolor packages.
-%     User interface is: |\mpcolor{teal}| or |\mpcolor[HTML]{008080}|,
-%     for example.
-%    \begin{macrocode}
-\def\mplibcolor#1{%
-  \def\set@color{\edef#1{1 withprescript "MPlibOverrideColor=\current@color"}}%
-  \color
-}
-\def\mplibnumbersystem#1{\directlua{luamplib.numbersystem = "#1"}}
+\def\mplibnumbersystem#1{\directlua{
+  local t = "#1"
+  if t == "binary" then t = "decimal" end
+  luamplib.numbersystem = t
+}}
 \def\mplibmakenocache#1{\mplibdomakenocache #1,*,}
 \def\mplibdomakenocache#1,{%
   \ifx\empty#1\empty
@@ -2018,17 +1836,7 @@ luamplib.colorconverter = colorconverter
   \fi
   \endgroup
 }
-%    \end{macrocode}
-%
-%    We use a dedicated scratchbox.
-%
-%    \begin{macrocode}
 \ifx\mplibscratchbox\undefined \newbox\mplibscratchbox \fi
-%    \end{macrocode}
-%
-%    We encapsulate the litterals.
-%
-%    \begin{macrocode}
 \def\mplibstarttoPDF#1#2#3#4{%
   \hbox\bgroup
   \xdef\MPllx{#1}\xdef\MPlly{#2}%
@@ -2042,9 +1850,6 @@ luamplib.colorconverter = colorconverter
   \setbox\mplibscratchbox\vbox\bgroup
   \noindent
 }
-%    \end{macrocode}
-%
-%    \begin{macrocode}
 \def\mplibstoptoPDF{%
   \egroup %
   \setbox\mplibscratchbox\hbox %
@@ -2063,11 +1868,6 @@ luamplib.colorconverter = colorconverter
   \box\mplibscratchbox
   \egroup
 }
-%    \end{macrocode}
-%
-%    Text items have a special handler.
-%
-%    \begin{macrocode}
 \def\mplibtextext#1#2#3#4#5{%
   \begingroup
   \setbox\mplibscratchbox\hbox
@@ -2084,11 +1884,6 @@ luamplib.colorconverter = colorconverter
   \box\mplibscratchbox
   \endgroup
 }
-%    \end{macrocode}
-%
-%    input luamplib.cfg when it exists
-%
-%    \begin{macrocode}
 \openin0=luamplib.cfg
 \ifeof0 \else
   \closein0

--- a/test-luamplib-latex.tex
+++ b/test-luamplib-latex.tex
@@ -3,6 +3,7 @@
 \usepackage{xcolor}
 \everymplib{ beginfig(0); }
 \everyendmplib{ endfig; }
+\mpliblegacybehavior{true}%
 \begin{document}
 \tracingcommands1
 A%

--- a/test-luamplib-plain.tex
+++ b/test-luamplib-plain.tex
@@ -2,6 +2,7 @@
 \input color
 \definecolor{orange}{rgb}{1,0.5,0}
 \input luamplib.sty
+\mpliblegacybehavior{true}%
 \everymplib{ beginfig(0); }\everyendmplib{ endfig; }
 \tracingcommands1
 A%


### PR DESCRIPTION
* huge changes, but mostly internal, so apparently not much difference
      from previous version.
* `\mplibforcehmode` makes mplibcode typeset in horizontal mode.
      `\mplibnoforcehmode` reverts the setting. The latter is default.
* `\mpliblegacybehavior{disable}` triggers a new mode of processing
      `verbatimtex .. etex`: along with `btex .. etex`, they will be processed
      sequentially one by one. Old behavior, being default, can be restored
      by declaring `\mpliblegacybehavior{enable}`.
      Incidentally, `verbatimtex .. etex` in MP input files is honored
      from this version, save those that contain `\documentclass`
      or `\begin{document}` etc, which is totally ignored.
* and ... address #79 