### PR TITLE
Separate instances support for LaTeX environment and respective tests

### DIFF
--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -846,7 +846,7 @@ end
 luamplib.codeinherit = false
 local mplibinstances = {}
 
-local function process (data)
+local function process (data, instancename)
 %    \end{macrocode}
 %
 %    The workaround of issue \#70 seems to be unnecessary, as we use
@@ -857,10 +857,17 @@ local function process (data)
 %    end
 %    \end{verbatim}
 %    \begin{macrocode}
-  local standalone = not luamplib.codeinherit
-  local currfmt = currentformat .. (luamplib.numbersystem or "scaled")
+  local defaultinstancename = currentformat .. (luamplib.numbersystem or "scaled")
     .. tostring(luamplib.textextlabel) .. tostring(luamplib.legacy_verbatimtex)
+  local currfmt = instancename or defaultinstancename
+  if #currfmt == 0 then
+    currfmt = defaultinstancename
+  end
   local mpx = mplibinstances[currfmt]
+  local standalone = false
+  if currfmt == defaultinstancename then
+    standalone = not luamplib.codeinherit
+  end
   if mpx and standalone then
     mpx:finish()
   end
@@ -1229,7 +1236,7 @@ local function unprotect_expansion (str)
   end
 end
 
-local function process_mplibcode (data)
+local function process_mplibcode (data, instancename)
 %    \end{macrocode}
 %
 %    This is needed for legacy behavior regarding |verbatimtex|
@@ -1283,7 +1290,7 @@ local function process_mplibcode (data)
     end)
   end
 
-  process(data)
+  process(data, instancename)
 end
 luamplib.process_mplibcode = process_mplibcode
 
@@ -2103,7 +2110,8 @@ luamplib.colorconverter = colorconverter
 %
 %    The \LaTeX-specific part: a new environment.
 %    \begin{macrocode}
-\newenvironment{mplibcode}{%
+\newenvironment{mplibcode}[1][]{%
+  \global\def\currentmpinstancename{#1}%
   \mplibtmptoks{}\ltxdomplibcode
 }{}
 \def\ltxdomplibcode{%
@@ -2117,7 +2125,7 @@ luamplib.colorconverter = colorconverter
   \mplibtmptoks\expandafter{\the\mplibtmptoks#1}%
   \def\mplibtemp@a{#2}%
   \ifx\mplib@mplibcode\mplibtemp@a
-    \directlua{luamplib.process_mplibcode([===[\the\mplibtmptoks]===])}%
+    \directlua{luamplib.process_mplibcode([===[\the\mplibtmptoks]===],"\currentmpinstancename")}%
     \end{mplibcode}%
   \else
     \mplibtmptoks\expandafter{\the\mplibtmptoks\end{#2}}%

--- a/test-luamplib-latex.tex
+++ b/test-luamplib-latex.tex
@@ -165,5 +165,59 @@ diameter:\Dia bp.%
   endfig;
 \end{mplibcode}%
 
+\vskip 2\baselineskip
+\mplibcodeinherit{disable}%
+
+\begin{mplibcode}[instanceOne]
+beginfig(1);
+a := 1cm;
+draw fullcircle scaled a;
+draw btex a circle with $d=a$ etex shifted (a,0);
+endfig;
+\end{mplibcode}%
+Current instance name is: \currentmpinstancename \vskip 2\baselineskip
+
+\begin{mplibcode}[instanceTwo]
+beginfig(1);
+if not known a:
+  draw btex code is not inherited from an instance with a different name etex;
+else:
+  errmessage("Variable was inherited from a different instance");
+fi;
+endfig;
+\end{mplibcode}%
+Current instance name is: \currentmpinstancename \vskip 2\baselineskip
+
+\begin{mplibcode}
+beginfig(1);
+if not known a:
+  draw btex code is not inherited if instance name is not listed etex;
+else:
+  errmessage("Variable was inherited from a different instance");
+fi;
+a := 1cm;
+endfig;
+\end{mplibcode}%
+Current instance name is: \currentmpinstancename (should be empty) \vskip 2\baselineskip
+
+\begin{mplibcode}
+beginfig(1);
+if not known a:
+  draw btex code is not inherited if mplibcodeinherit is disabled and instance name is not explicitly set etex;
+else:
+  errmessage("Variable was inherited when code inheritance is turned off and instance name is not set");
+fi;
+endfig;
+\end{mplibcode}%
+Current instance name is: \currentmpinstancename (should be empty) \vskip 2\baselineskip
+
+\begin{mplibcode}[instanceOne]
+beginfig(1);
+draw unitsquare scaled a;
+draw btex a square with side $=a$, inherited from the same instance etex shifted (3/2a, 1/2a);
+endfig;
+\end{mplibcode}%
+Current instance name is: \currentmpinstancename \vskip 2\baselineskip
+
 \tracingcommands0
 \end{document}


### PR DESCRIPTION
This adds the support for several named MetaPost instances in LaTeX `mplibcode` environment. Respective tests are added to `test-luamplib-latex.tex`.

Syntax is like so:
```
\begin{mplibcode}[instanceName]
% some mp code
\end{mplibcode}
```
Behaviour is as follows. 

- All the variables and functions are shared only among all the environments belonging to the same instance.
- `\mplibcodeinherit` only affects environments with no instance name set (since if a name is set, the code is intended to be reused at some point).
- `btex ... etex` labels still exist separately and require `\mplibglobaltextext`
- When an instance names is set, respective `\currentmpinstancename` is set