### PR TITLE
using sockets in tagging code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 *.mp
 *.fls
 *.dvi
+*.html

--- a/NEWS
+++ b/NEWS
@@ -5,7 +5,7 @@
      Declare '\DocumentMetadata{debug=BBox}' instead.
 
    * Tagging option 'off' is newly introduced.
-     Given this key, luamplib does nothing about tagging.
+     Given this key, nothing will be tagged by luamplib.
 
    * Tagging option 'tagging-setup' is newly introduced.
      The value of this key is a key-value list of other tagging options.

--- a/NEWS
+++ b/NEWS
@@ -4,14 +4,14 @@
    * Tagging key 'off' is newly introduced.
      This key, being a synonym of 'tag=false', deactivates tagging.
 
-   * Tagging keys 'actualtext', 'text', and 'off' force horizontal mode
-     according to the definition of \prependtomplibbox.
-
    * Tagging key 'tagging-setup' is newly introduced.
      The value of this key is a key-value list of other tagging options.
 
    * Tagging Key 'debug' is removed.
      Declare '\DocumentMetadata{debug=BBox}' instead.
+
+   * Tagging keys 'actualtext', 'text', and 'off' force horizontal mode
+     according to the definition of \prependtomplibbox.
 
    * more robust 'mplibgraphictext' macro
 

--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,9 @@
    * Tagging key 'tagging-setup' is newly introduced.
      The value of this key is a key-value list of other tagging options.
 
+   * Tagging Key 'debug' is removed.
+     Declare '\DocumentMetadata{debug=BBox}' instead.
+
    * more robust 'mplibgraphictext' macro
 
 2025/03/20 2.37.2

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,14 @@
                        History of the luamplib package
 
+2025/xx/xx 2.37.3
+   * Tagging key 'off' is newly introduced.
+     Given this key, luamplib does nothing about tagging.
+
+   * Tagging keys 'actualtext' and 'text' force horizontal mode
+     according to the definition of \prependtomplibbox.
+
+   * more robust 'mplibgraphictext' macro
+
 2025/03/20 2.37.2
    * Formerly, it was not possible to give shading effect to a textual picture
    inside a tiling pattern. This limitation is now lifted.

--- a/NEWS
+++ b/NEWS
@@ -2,10 +2,13 @@
 
 2025/xx/xx 2.37.3
    * Tagging key 'off' is newly introduced.
-     Given this key, luamplib does nothing about tagging.
+     This key, being a synonym of 'tag=false', deactivates tagging.
 
-   * Tagging keys 'actualtext' and 'text' force horizontal mode
+   * Tagging keys 'actualtext', 'text', and 'off' force horizontal mode
      according to the definition of \prependtomplibbox.
+
+   * Tagging key 'tagging-setup' is newly introduced.
+     The value of this key is a key-value list of other tagging options.
 
    * more robust 'mplibgraphictext' macro
 

--- a/NEWS
+++ b/NEWS
@@ -1,18 +1,21 @@
                        History of the luamplib package
 
-2025/xx/xx 2.37.3
+2025/05/15 2.37.3
    * Tagging option 'debug' is removed.
      Declare '\DocumentMetadata{debug=BBox}' instead.
 
+   * Tagging option 'correct-BBox' is renamed to 'adjust-BBox'.
+
    * Tagging option 'off' is newly introduced.
      Given this key, nothing will be tagged by luamplib.
-
-   * Tagging option 'correct-BBox' is renamed to 'adjust-BBox'.
 
    * Tagging option 'tagging-setup' is newly introduced.
      The value of this key is a key-value list of other tagging options.
 
    * Tagging options 'actualtext' and 'text' do not force horizontal mode.
+
+   * When the text of a tex-text box starts with '[taggingoff]', it will not
+     be tagged at all even in the text mode.
 
    * more robust 'mplibgraphictext' macro
 

--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,8 @@
    * Tagging option 'off' is newly introduced.
      Given this key, nothing will be tagged by luamplib.
 
+   * Tagging option 'correct-BBox' is renamed to 'adjust-BBox'.
+
    * Tagging option 'tagging-setup' is newly introduced.
      The value of this key is a key-value list of other tagging options.
 

--- a/NEWS
+++ b/NEWS
@@ -1,17 +1,16 @@
                        History of the luamplib package
 
 2025/xx/xx 2.37.3
-   * Tagging key 'off' is newly introduced.
-     This key, being a synonym of 'tag=false', deactivates tagging.
-
-   * Tagging key 'tagging-setup' is newly introduced.
-     The value of this key is a key-value list of other tagging options.
-
-   * Tagging Key 'debug' is removed.
+   * Tagging option 'debug' is removed.
      Declare '\DocumentMetadata{debug=BBox}' instead.
 
-   * Tagging keys 'actualtext', 'text', and 'off' force horizontal mode
-     according to the definition of \prependtomplibbox.
+   * Tagging option 'off' is newly introduced.
+     Given this key, luamplib does nothing about tagging.
+
+   * Tagging option 'tagging-setup' is newly introduced.
+     The value of this key is a key-value list of other tagging options.
+
+   * Tagging options 'actualtext' and 'text' do not force horizontal mode.
 
    * more robust 'mplibgraphictext' macro
 

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -5228,7 +5228,7 @@ end
 \msg_new:nnn {luamplib}{figure-text-reuse}
 {
   tex-text~box~#1~probably~is~incorrectly~tagged.~
-  Reusing~a~box~from~non-text~mode~is~not~recommended.~
+  Reusing~a~box~in~text~mode~is~strongly~discouraged.~
   Check~the~resulting~PDF.
 }
 \msg_new:nnn {luamplib}{mplibgroup-text-mode}
@@ -5286,6 +5286,7 @@ end
     {
       \exp_args:Nc \tag_struct_use_num:n {luamplib.taggedbox.#1}
       #2
+      \cs_undefine:c {luamplib.taggedbox.#1}
     }
     {
       \msg_warning:nnn{luamplib}{figure-text-reuse}{#1}

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -565,10 +565,10 @@ See source file '\inFileName' for licencing and contact information.
 % \begin{description}
 % \item[\texttt{alt=}\meta{text}] starts a |Figure| tag by default
 %   (that is, if no |tag| option mentioned below is given) and
-%   sets an alternative text of the figure from the \meta{text}.
+%   sets an alternate text of the figure from the \meta{text}.
 %   BBox info will be added automatically to the PDF\@.
 %   This key is needed for ordinary \metapost figures.
-%   You can change alternative text within \metapost code as well:
+%   You can change alternate text within \metapost code as well:
 %   |VerbatimTeX| |"\mplibalttext|\marg{text}|";|
 % \item[\texttt{actualtext=}\meta{text}] starts a |Span| tag implicitly and sets an actualtext from the \meta{text}.
 %   BBox info will not be added.
@@ -604,11 +604,11 @@ See source file '\inFileName' for licencing and contact information.
 %   unless the value is |artifact|, |text| or |false|.
 %   Among these the last one, |tag=false|, is a synonym of the |off| option just mentioned.
 %   For instance, you can set `|tag=Formula,| |alt=|\meta{text}' to get |Formula| structure
-%   with the alternative text.
+%   with the alternate text.
 % \item[\texttt{correct-BBox=}\meta{dimens}] You can correct the BBox attribute of the figure
 %   with space-separated four dimensional values, which will be added to the
 %   automatically-calculated BBox values.
-%   To draw the bounding box of a figure for checking, you can declare
+%   To draw the bounding box for checking, you can declare
 %   |\DocumentMetadata|\allowbreak|{debug=BBox}|
 %   after |\DocumentMetadata{tagging=|\allowbreak|on}| setup is completed.
 % \item[\texttt{tagging-setup=}\meta{key-val list}]
@@ -5223,6 +5223,7 @@ end
   \let\mplibactualtext \mplibalttext
   \endinput\fi
 \ExplSyntaxOn
+\tl_new:N \l__luamplib_notag_keyval_tl
 \tl_new:N \l__luamplib_tag_envname_tl
 \tl_set:Nn\l__luamplib_tag_envname_tl {mplibcode}
 \tl_new:N \l__luamplib_tag_alt_tl
@@ -5234,8 +5235,8 @@ end
 \bool_new:N \l__luamplib_tag_usetext_bool
 \bool_new:N \g__luamplib_tag_asgroup_bool
 \bool_new:N \l__luamplib_tag_BBox_bool
-\seq_new:N\l__luamplib_tag_bboxcorr_seq
 \bool_new:N\l__luamplib_tag_bboxcorr_bool
+\seq_new:N\l__luamplib_tag_bboxcorr_seq
 \tl_new:N \l__luamplib_BBox_label_tl
 \tl_new:N \l__luamplib_BBox_llx_tl
 \tl_new:N \l__luamplib_BBox_lly_tl
@@ -5248,7 +5249,7 @@ end
 }
 \msg_new:nnn{luamplib}{alt-text-missing}
 {
-  Alternative~text~for~#1~is~missing.\\
+  Alternate~text~for~#1~is~missing.\\
   Using~the~default~value~'#2'~instead.
 }
 %    \end{macrocode}
@@ -5383,7 +5384,7 @@ end
 %    \begin{macrocode}
 \NewSocket{tagsupport/luamplib/begin}{0}
 \NewSocket{tagsupport/luamplib/end}{0}
-\NewSocketPlug{tagsupport/luamplib/begin}{figure}
+\NewSocketPlug{tagsupport/luamplib/begin}{alt}
 {
     \tag_mc_end_push:
     \tl_if_empty:NT\l__luamplib_tag_alt_tl
@@ -5399,7 +5400,7 @@ end
     }
     \tag_mc_begin:n{}
 }
-\NewSocketPlug{tagsupport/luamplib/end}{figure}
+\NewSocketPlug{tagsupport/luamplib/end}{alt}
 {
     \tag_mc_end:
     \tag_struct_end:
@@ -5431,120 +5432,8 @@ end
     \tag_mc_end:
     \tag_mc_begin_pop:n{}
 }
-\AssignSocketPlug{tagsupport/luamplib/begin}{figure}
-\AssignSocketPlug{tagsupport/luamplib/end}{figure}
-%    \end{macrocode}
-% A sockets to force horizontal mode upon |text|, |actualtext|, and |off|
-%    \begin{macrocode}
-\NewSocket{tagsupport/luamplib/hmode/force}{0}
-\NewSocketPlug{tagsupport/luamplib/hmode/force}{default}
-{
-  \mode_if_vertical:T
-  {
-    \cs_if_eq:NNTF \prependtomplibbox \relax
-    {
-      \noindent
-      \aftergroup \par
-    }
-    {
-      \bool_lazy_any:nTF
-      {
-        { \cs_if_eq_p:NN \prependtomplibbox \leavevmode }
-        { \cs_if_eq_p:NN \prependtomplibbox \noindent }
-        { \cs_if_eq_p:NN \prependtomplibbox \mode_leave_vertical: }
-      }
-      { \prependtomplibbox }
-      {
-        \str_set:Ne \l_tmpa_str {\cs_meaning:N \prependtomplibbox}
-        \clist_set:Nn \l_tmpa_clist
-          {\unhbox \voidb@x,\noindent,\mode_leave_vertical:,\tex_indent:D,\indent}
-        \bool_set_false:N \l_tmpa_bool
-        \clist_map_inline:Nn \l_tmpa_clist
-          {
-            \str_if_in:NnT \l_tmpa_str {##1}
-            {
-              ##1
-              \bool_set_true:N \l_tmpa_bool
-              \clist_map_break:
-             }
-          }
-        \bool_if:NF \l_tmpa_bool
-        {
-          \noindent         % prone to error!
-          \aftergroup \par
-        }
-      }
-    }
-  }
-}
-\AssignSocketPlug{tagsupport/luamplib/hmode/force}{default}
-%    \end{macrocode}
-% Key-value options
-%    \begin{macrocode}
-\keys_define:nn{luamplib/tag}
-  {
-    ,alt .code:n =
-      {
-        \bool_set_true:N \l__luamplib_tag_BBox_bool
-        \tl_set:Ne\l__luamplib_tag_alt_tl{\text_purify:n{#1}}
-      }
-    ,alt .groups:n = {tagging}
-    ,actualtext .code:n =
-      {
-        \tl_set:Ne\l__luamplib_tag_actual_tl{\text_purify:n{#1}}
-        \AssignSocketPlug{tagsupport/luamplib/begin}{actualtext}
-        \AssignSocketPlug{tagsupport/luamplib/end}{actualtext}
-        \UseTaggingSocket{luamplib/hmode/force}
-      }
-    ,actualtext .groups:n = {tagging}
-    ,artifact .code:n =
-      {
-        \AssignSocketPlug{tagsupport/luamplib/begin}{artifact}
-        \AssignSocketPlug{tagsupport/luamplib/end}{artifact}
-      }
-    ,artifact .groups:n = {tagging}
-    ,text .code:n =
-      {
-        \tag_if_active:T { \bool_set_true:N \l__luamplib_tag_usetext_bool }
-        \AssignSocketPlug{tagsupport/luamplib/begin}{artifact}
-        \AssignSocketPlug{tagsupport/luamplib/end}{artifact}
-        \UseTaggingSocket{luamplib/hmode/force}
-      }
-    ,text .groups:n = {tagging}
-    ,off .code:n =
-      {
-        \UseTaggingSocket{luamplib/hmode/force}
-        \SuspendTagging{luamplib/tag/off}
-      }
-    ,off .groups:n = {tagging}
-    ,tag .code:n =
-      {
-        \str_case:nnF {#1}
-          {
-            {false}    { \keys_set:nn {luamplib/tag} {off} }
-            {text}     { \keys_set:nn {luamplib/tag} {text} }
-            {artifact} { \keys_set:nn {luamplib/tag} {artifact} }
-          }
-          {
-            \bool_set_true:N \l__luamplib_tag_BBox_bool
-            \tl_set:Nn\l__luamplib_tag_struct_tl{#1}
-          }
-      }
-    ,tag .groups:n = {tagging}
-    ,correct-BBox .code:n =
-      {
-        \bool_set_true:N \l__luamplib_tag_bboxcorr_bool
-        \seq_set_split:Nnn \l__luamplib_tag_bboxcorr_seq{~}{#1~0pt~0pt~0pt~0pt}
-      }
-    ,correct-BBox .groups:n = {tagging}
-    ,tagging-setup .code:n =
-      {
-        \keys_set_groups:nnn {luamplib/tag} {tagging} {#1}
-      }
-    ,instance .code:n = { \tl_gset:Nn \currentmpinstancename {#1} }
-    ,instancename .meta:n = { instance = {#1} }
-    ,unknown .code:n = { \tl_gset:Ne \currentmpinstancename {\l_keys_key_str} }
-  }
+\AssignSocketPlug{tagsupport/luamplib/begin}{alt}
+\AssignSocketPlug{tagsupport/luamplib/end}{alt}
 %    \end{macrocode}
 % A socket for BBox attribute
 %    \begin{macrocode}
@@ -5659,6 +5548,66 @@ end
 }
 \AssignSocketPlug{tagsupport/luamplib/bbox}{default}
 %    \end{macrocode}
+% A sockets to force horizontal mode upon |text|, |actualtext|, and |off|
+%    \begin{macrocode}
+\cs_set_nopar:Npn \__luamplib_tag_hmode_force:
+{
+  \mode_if_vertical:T
+  {
+    \cs_if_eq:NNTF \prependtomplibbox \relax
+    {
+      \noindent
+      \aftergroup \par
+    }
+    {
+      \bool_lazy_any:nTF
+      {
+        { \cs_if_eq_p:NN \prependtomplibbox \leavevmode }
+        { \cs_if_eq_p:NN \prependtomplibbox \noindent }
+        { \cs_if_eq_p:NN \prependtomplibbox \mode_leave_vertical: }
+      }
+      { \prependtomplibbox }
+      {
+        \str_set:Ne \l_tmpa_str {\cs_meaning:N \prependtomplibbox}
+        \clist_set:Nn \l_tmpa_clist
+          {\unhbox \voidb@x,\noindent,\mode_leave_vertical:,\tex_indent:D,\indent}
+        \bool_set_false:N \l_tmpa_bool
+        \clist_map_inline:Nn \l_tmpa_clist
+          {
+            \str_if_in:NnT \l_tmpa_str {##1}
+            {
+              ##1
+              \bool_set_true:N \l_tmpa_bool
+              \clist_map_break:
+             }
+          }
+        \bool_if:NF \l_tmpa_bool
+        {
+          \noindent         % prone to error!
+          \aftergroup \par
+        }
+      }
+    }
+  }
+}
+\NewSocket{tagsupport/luamplib/starting}{0}
+\NewSocketPlug{tagsupport/luamplib/starting}{default}{}
+\NewSocketPlug{tagsupport/luamplib/starting}{actualtext}
+{
+  \__luamplib_tag_hmode_force:
+}
+\NewSocketPlug{tagsupport/luamplib/starting}{text}
+{
+  \bool_set_true:N \l__luamplib_tag_usetext_bool
+  \__luamplib_tag_hmode_force:
+}
+\NewSocketPlug{tagsupport/luamplib/starting}{off}
+{
+  \__luamplib_tag_hmode_force:
+  \SuspendTagging{luamplib/tag/off}
+}
+\AssignSocketPlug{tagsupport/luamplib/starting}{default}
+%    \end{macrocode}
 % Sockets for mplibgroup
 %    \begin{macrocode}
 \NewSocket{tagsupport/luamplib/mplibgroup/begin}{0}
@@ -5681,6 +5630,71 @@ end
 }
 \AssignSocketPlug{tagsupport/luamplib/mplibgroup/begin}{default}
 \AssignSocketPlug{tagsupport/luamplib/mplibgroup/end}{default}
+%    \end{macrocode}
+% Key-value options
+%    \begin{macrocode}
+\keys_define:nn{luamplib/tag}
+  {
+    ,alt .code:n =
+      {
+        \bool_set_true:N \l__luamplib_tag_BBox_bool
+        \tl_set:Ne\l__luamplib_tag_alt_tl{\text_purify:n{#1}}
+        \AssignSocketPlug{tagsupport/luamplib/begin}{alt}
+        \AssignSocketPlug{tagsupport/luamplib/end}{alt}
+        \AssignSocketPlug{tagsupport/luamplib/starting}{default}
+      }
+    ,actualtext .code:n =
+      {
+        \tl_set:Ne\l__luamplib_tag_actual_tl{\text_purify:n{#1}}
+        \AssignSocketPlug{tagsupport/luamplib/begin}{actualtext}
+        \AssignSocketPlug{tagsupport/luamplib/end}{actualtext}
+        \AssignSocketPlug{tagsupport/luamplib/starting}{actualtext}
+      }
+    ,artifact .code:n =
+      {
+        \AssignSocketPlug{tagsupport/luamplib/begin}{artifact}
+        \AssignSocketPlug{tagsupport/luamplib/end}{artifact}
+        \AssignSocketPlug{tagsupport/luamplib/starting}{default}
+      }
+    ,text .code:n =
+      {
+        \AssignSocketPlug{tagsupport/luamplib/begin}{artifact}
+        \AssignSocketPlug{tagsupport/luamplib/end}{artifact}
+        \AssignSocketPlug{tagsupport/luamplib/starting}{text}
+      }
+    ,off .code:n =
+      {
+        \AssignSocketPlug{tagsupport/luamplib/starting}{off}
+      }
+    ,tag .code:n =
+      {
+        \str_case:nnF {#1}
+          {
+            {false}    { \keys_set:nn {luamplib/tag} {off} }
+            {text}     { \keys_set:nn {luamplib/tag} {text} }
+            {artifact} { \keys_set:nn {luamplib/tag} {artifact} }
+          }
+          {
+            \bool_set_true:N \l__luamplib_tag_BBox_bool
+            \tl_set:Nn\l__luamplib_tag_struct_tl{#1}
+          }
+      }
+    ,correct-BBox .code:n =
+      {
+        \bool_set_true:N \l__luamplib_tag_bboxcorr_bool
+        \seq_set_split:Nnn \l__luamplib_tag_bboxcorr_seq{~}{#1~0pt~0pt~0pt~0pt}
+      }
+    ,tagging-setup .code:n =
+      {
+        \keys_set_known:nn {luamplib/tag} {#1}
+      }
+  }
+\keys_define:nn {luamplib/notag}
+  {
+    ,instance .code:n = { \tl_gset:Nn \currentmpinstancename {#1} }
+    ,instancename .meta:n = { instance = {#1} }
+    ,unknown .code:n = { \tl_gset:Ne \currentmpinstancename {\l_keys_key_str} }
+  }
 %    \end{macrocode}
 % Redefine our macros
 %    \begin{macrocode}
@@ -5727,9 +5741,11 @@ end
   {
     \tl_set:Nn \l__luamplib_tag_envname_tl {mplibcode}
     \tl_gset_eq:NN \currentmpinstancename \c_empty_tl
-    \keys_set:ne{luamplib/tag}{#1}
+    \keys_set_known:neN {luamplib/tag} {#1} \l__luamplib_notag_keyval_tl
+    \keys_set:nV {luamplib/notag} \l__luamplib_notag_keyval_tl
     \tl_if_empty:NF \currentmpinstancename
       { \tl_set:Nn\l__luamplib_tag_alt_dflt_tl {metapost~figure~\currentmpinstancename} }
+    \UseTaggingSocket{luamplib/starting}
     \mplibtmptoks{}\ltxdomplibcode
   }
 \RenewDocumentCommand\mpfig{s O{}}
@@ -5739,9 +5755,11 @@ end
     {\mplibprempfig *}
     {
       \tl_set:Nn \l__luamplib_tag_envname_tl {mpfig}
-      \keys_set:ne{luamplib/tag}{#2}
+      \keys_set_known:neN {luamplib/tag} {#2} \l__luamplib_notag_keyval_tl
+      \keys_set:nV {luamplib/notag} \l__luamplib_notag_keyval_tl
       \tl_if_empty:NF \mpfiginstancename
         { \tl_set:Nn\l__luamplib_tag_alt_dflt_tl {metapost~figure~\mpfiginstancename} }
+      \UseTaggingSocket{luamplib/starting}
       \mplibmainmpfig
     }
   }
@@ -5749,8 +5767,10 @@ end
   {
     \begingroup
     \tl_set:Nn \l__luamplib_tag_envname_tl {usemplibgroup}
-    \keys_set:ne{luamplib/tag}{#1}
+    \keys_set_known:neN {luamplib/tag} {#1} \l__luamplib_notag_keyval_tl
+    \keys_set:nV {luamplib/notag} \l__luamplib_notag_keyval_tl
     \tl_set:Nn\l__luamplib_tag_alt_dflt_tl {metapost~figure~#2}
+    \UseTaggingSocket{luamplib/starting}
     \prependtomplibbox\hbox dir TLT\bgroup
     \UseTaggingSocket{luamplib/begin}
     \setbox\mplibscratchbox\hbox\bgroup

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -2778,6 +2778,9 @@ def mplibgraphictext_ (expr t) text rest =
   let withfillcolor = fillcolor; let withdrawcolor = drawcolor;
   def alsoordoublepath expr p = if picture p: also else: doublepath fi p enddef;
   addto graphictextpic alsoordoublepath (origin--cycle) rest; graphictextpic:=nullpicture;
+  def fakebold  primary c = enddef;
+  let fillcolor = fakebold; let drawcolor = fakebold;
+  let withfillcolor = fillcolor; let withdrawcolor = drawcolor;
   image(draw runscript("return luamplib.graphictext([===["&t&"]===],"
     & decimal fb &",'"& fc &"','"& dc &"')") rest;)
   endgroup;

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -5288,7 +5288,7 @@ end
       { \tag_struct_begin:n{tag=NonStruct, stash} }
     \cs_gset_nopar:cpe {luamplib.taggedbox.#1} {\tag_get:n{struct_num}}
 %    \end{macrocode}
-% TODO: We force an MC. Otherwize |a| and |b| in |btex a $x$ b etex| are not tagged.
+% TODO: We force an MC. Otherwise |a| and |b| in |btex a $x$ b etex| are not tagged.
 %    \begin{macrocode}
     \tag_mc_begin:n{tag=text}
     #2

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -5267,8 +5267,6 @@ end
 }
 \socket_new_plug:nnn{tagsupport/luamplib/textext/put}{default}
 {
-  \bool_if:NTF \l__luamplib_tag_usetext_bool
-  {
     \tag_mc_end:
     \cs_if_exist:cTF {luamplib.taggedbox.#1}
     {
@@ -5284,12 +5282,6 @@ end
       \tag_mc_end:
     }
     \tag_mc_begin:n{artifact}
-  }
-  {
-    \int_set:Nn \l_tmpa_int {#1}
-    \tag_mc_reset_box:N \l_tmpa_int
-    #2
-  }
 }
 \socket_assign_plug:nn{tagsupport/luamplib/textext/begin}{default}
 \socket_assign_plug:nn{tagsupport/luamplib/textext/end}{default}
@@ -5323,8 +5315,16 @@ end
 \cs_set_nopar:Npn \mplibputtextbox #1
 {
   \vbox to 0pt{\vss\hbox to 0pt{
-    \tag_resume:n{\mplibputtextbox}
-    \tag_socket_use:nnn{luamplib/textext/put}{#1}{\raise\dp#1\copy#1}
+    \bool_if:NTF \l__luamplib_tag_usetext_bool
+    {
+      \tag_resume:n{\mplibputtextbox}
+      \tag_socket_use:nnn{luamplib/textext/put}{#1}{\raise\dp#1\copy#1}
+    }
+    {
+      \int_set:Nn \l_tmpa_int {#1}
+      \tag_mc_reset_box:N \l_tmpa_int
+      \raise\dp#1\copy#1
+    }
   \hss}}
 }
 %    \end{macrocode}
@@ -5384,7 +5384,7 @@ end
 %    \end{macrocode}
 % A macro for BBox attribute
 %    \begin{macrocode}
-\cs_set_nopar:Npn \luamplib_tag_bbox_attribute:n #1
+\cs_set_nopar:Npn \__luamplib_tag_bbox_attribute:n #1
 {
   \tl_set:Ne \l_tmpa_tl {luamplib.BBox.\tag_get:n{struct_num}}
   \tex_savepos:D
@@ -5531,7 +5531,7 @@ end
 }
 \socket_new_plug:nnn{tagsupport/luamplib/figure/end}{alt}
 {
-    \luamplib_tag_bbox_attribute:n {#1}
+    \__luamplib_tag_bbox_attribute:n {#1}
     #2
     \tl_use:N \l__luamplib_tag_bbox_draw_tl
     \tag_mc_end:

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -5203,7 +5203,7 @@ end
     }
   \RenewDocumentCommand\mplibcode{O{}}
     {
-      \tl_gset_eq:NN \currentmpinstancename \c_empty_tl
+      \tl_gclear:N \currentmpinstancename
       \keys_set:ne{luamplib/notagging}{#1}
       \mplibtmptoks{}\ltxdomplibcode
     }
@@ -5228,13 +5228,19 @@ end
 \tl_new:N \l__luamplib_BBox_ury_tl
 \msg_new:nnn {luamplib}{figure-text-reuse}
 {
-  tex-text~box~#1~probably~is~incorrectly~tagged.\\
+  tex-text~box~#1~probably~is~incorrectly~tagged.~
   Reusing~a~box~from~non-text~mode~is~strongly~discouraged.~
+  Check~the~resulting~PDF.
+}
+\msg_new:nnn {luamplib}{mplibgroup-text-mode}
+{
+  mplibgroup~'#1'~probably~is~incorrectly~tagged.~
+  Using~mplibgroup~in~text~mode~is~strongly~discouraged.~
   Check~the~resulting~PDF.
 }
 \msg_new:nnn{luamplib}{alt-text-missing}
 {
-  Alternate~text~for~#1~is~missing.\\
+  Alternate~text~for~#1~is~missing.~
   Using~the~default~value~'#2'~instead.
 }
 %    \end{macrocode}
@@ -5242,14 +5248,15 @@ end
 %    \begin{macrocode}
 \socket_new:nn{tagsupport/luamplib/textext/begin}{1}
 \socket_new:nn{tagsupport/luamplib/textext/end}{0}
-\socket_new:nn{tagsupport/luamplib/textext/put}{2}
+\socket_new:nn{tagsupport/luamplib/textext/put/begin}{1}
+\socket_new:nn{tagsupport/luamplib/textext/put/end}{1}
 \socket_new_plug:nnn{tagsupport/luamplib/textext/begin}{default}
 {
     \tag_mc_end_push:
-    \tag_struct_begin:n{tag=NonStruct,stash}
-    \cs_gset_nopar:cpe {luamplib.tagbox.#1} {\tag_get:n{struct_num}}
+    \tag_struct_begin:n{tag=NonStruct, stash, parent-tag=text}
+    \cs_gset_nopar:cpe {luamplib.taggedbox.#1} {\tag_get:n{struct_num}}
 %    \end{macrocode}
-% TODO: We force an MC. If not, |a| and |b| in |btex a $x$ b etex| are not tagged.
+% TODO: We force an MC. Otherwize |a| and |b| in |btex a $x$ b etex| are not tagged.
 %    \begin{macrocode}
     \tag_mc_begin:n{tag=text}
 }
@@ -5259,31 +5266,42 @@ end
     \tag_struct_end:
     \tag_mc_begin_pop:n{}
 }
-\socket_new_plug:nnn{tagsupport/luamplib/textext/put}{default}
+\socket_new_plug:nnn{tagsupport/luamplib/textext/put/begin}{default}
 {
+  \bool_if:NTF \l__luamplib_tag_usetext_bool
+  {
     \tag_mc_end:
-    \cs_if_exist:cTF {luamplib.tagbox.#1}
+    \cs_if_exist:cTF {luamplib.taggedbox.#1}
     {
-      \tag_struct_use_num:n {\csname luamplib.tagbox.#1\endcsname}
-      #2
+      \exp_args:Nc \tag_struct_use_num:n {luamplib.taggedbox.#1}
     }
     {
       \msg_warning:nnn{luamplib}{figure-text-reuse}{#1}
       \tag_mc_begin:n{}
-      \__luamplib_tag_box_reset_put:nn{#1}{#2}
+      \int_set:Nn \l_tmpa_int {#1}
+      \tag_mc_reset_box:N \l_tmpa_int
+    }
+  }
+  {
+    \int_set:Nn \l_tmpa_int {#1}
+    \tag_mc_reset_box:N \l_tmpa_int
+  }
+}
+\socket_new_plug:nnn{tagsupport/luamplib/textext/put/end}{default}
+{
+  \bool_if:NT \l__luamplib_tag_usetext_bool
+  {
+    \cs_if_exist:cF {luamplib.taggedbox.#1}
+    {
       \tag_mc_end:
     }
     \tag_mc_begin:n{artifact}
+  }
 }
 \socket_assign_plug:nn{tagsupport/luamplib/textext/begin}{default}
 \socket_assign_plug:nn{tagsupport/luamplib/textext/end}{default}
-\socket_assign_plug:nn{tagsupport/luamplib/textext/put}{default}
-\cs_set_nopar:Npn \__luamplib_tag_box_reset_put:nn #1 #2
-{
-  \int_set:Nn \l_tmpa_int {#1}
-  \tag_mc_reset_box:N \l_tmpa_int
-  #2
-}
+\socket_assign_plug:nn{tagsupport/luamplib/textext/put/begin}{default}
+\socket_assign_plug:nn{tagsupport/luamplib/textext/put/end}{default}
 \cs_set_nopar:Npn \luamplibtagtextbegin #1
 {
 %    \end{macrocode}
@@ -5296,8 +5314,7 @@ end
     \tag_socket_use:nn{luamplib/textext/begin}{#1}
   }
   {
-    \tag_if_active:TF { \bool_set_true:N \l_tmpa_bool }
-                      { \bool_set_false:N \l_tmpa_bool }
+    \bool_set:Nn \l_tmpa_bool { \tag_if_active_p: }
     \tag_suspend:n{\luamplibtagtextbegin}
   }
 }
@@ -5313,15 +5330,11 @@ end
 }
 \cs_set_nopar:Npn \mplibputtextbox #1
 {
-  \vbox to 0pt{\vss\hbox to 0pt{%
-    \bool_if:NTF \l__luamplib_tag_usetext_bool
-    {
-      \tag_resume:n{\mplibputtextbox}
-      \tag_socket_use:nnn{luamplib/textext/put}{#1}{\raise\dp#1\copy#1}
-    }
-    {
-      \__luamplib_tag_box_reset_put:nn{#1}{\raise\dp#1\copy#1}
-    }
+  \vbox to 0pt{\vss\hbox to 0pt{
+    \tag_resume:n{\mplibputtextbox}
+    \tag_socket_use:nn{luamplib/textext/put/begin}{#1}
+    \raise\dp#1\copy#1
+    \tag_socket_use:nn{luamplib/textext/put/end}{#1}
   \hss}}
 }
 %    \end{macrocode}
@@ -5353,12 +5366,17 @@ end
 %    \end{macrocode}
 % Sockets for mplibgroup
 %    \begin{macrocode}
-\socket_new:nn{tagsupport/luamplib/mplibgroup/begin}{0}
+\socket_new:nn{tagsupport/luamplib/mplibgroup/begin}{1}
 \socket_new:nn{tagsupport/luamplib/mplibgroup/end}{0}
 \socket_new_plug:nnn{tagsupport/luamplib/mplibgroup/begin}{default}
 {
     \bool_if:NT \l__luamplib_tag_usetext_bool
     {
+      \cs_if_free:cT {luamplib.mplibgroup.text.#1}
+      {
+        \msg_warning:nnn {luamplib} {mplibgroup-text-mode} {#1}
+        \cs_gset_nopar:cpn {luamplib.mplibgroup.text.#1} {#1}
+      }
       \tag_mc_end:
       \tag_mc_begin:n{}
     }
@@ -5448,7 +5466,7 @@ end
     { \dim_to_decimal_in_bp:n { \l__luamplib_BBox_lly_tl bp + \ht#1 + \dp#1 } }
   \bool_if:NT \l__luamplib_tag_bboxcorr_bool
   {
-    \int_set_eq:NN \l_tmpa_int \c_zero_int
+    \int_zero:N \l_tmpa_int
     \tl_map_inline:nn
     {
       \l__luamplib_BBox_llx_tl
@@ -5677,7 +5695,7 @@ end
 \RenewDocumentCommand\mplibcode{O{}}
 {
   \tl_set:Nn \l__luamplib_tag_envname_tl {mplibcode}
-  \tl_gset_eq:NN \currentmpinstancename \c_empty_tl
+  \tl_gclear:N \currentmpinstancename
   \keys_set_known:neN {luamplib/tagging} {#1} \l_tmpa_tl
   \keys_set:nV {luamplib/instance} \l_tmpa_tl
   \tl_set_eq:NN \l__luamplib_tag_alt_dflt_tl \currentmpinstancename
@@ -5699,12 +5717,11 @@ end
   \begingroup
   \tl_set:Nn \l__luamplib_tag_envname_tl {usemplibgroup}
   \keys_set_known:ne {luamplib/tagging} {#1}
-  \tl_set:Nn \l__luamplib_tag_alt_dflt_tl {#2}
   \tag_socket_use:n{luamplib/figure/init}
   \prependtomplibbox\hbox dir~TLT\bgroup
-    \tag_socket_use:nn{luamplib/figure/begin}\l__luamplib_tag_alt_dflt_tl
+    \tag_socket_use:nn{luamplib/figure/begin}{#2}
     \setbox\mplibscratchbox\hbox\bgroup
-      \tag_socket_use:n{luamplib/mplibgroup/begin}
+      \tag_socket_use:n{luamplib/mplibgroup/begin}{#2}
       \csname luamplib.group.#2\endcsname
       \tag_socket_use:n{luamplib/mplibgroup/end}
     \egroup

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -838,13 +838,12 @@ See source file '\inFileName' for licencing and contact information.
 %\begin{verbatim}
 %      \begin{mplibcode}
 %        beginfig(2)
-%        picture pic;
-%        pic = mplibgraphictext "\bfseries\TeX"
-%                fakebold 1/2
-%                fillcolor 1/3[red,blue]            % paints the pattern
-%                drawcolor 2/3[red,blue]
-%                scaled 10 ;
-%        draw pic withmppattern "pattnocolor" ;
+%        draw mplibgraphictext "\bfseries\TeX"
+%               fakebold 1
+%               fillcolor 1/3[red,blue]            % paints the pattern
+%               drawcolor 2/3[red,blue]
+%               scaled 10
+%               withmppattern "pattnocolor" ;
 %        endfig;
 %      \end{mplibcode}
 %\end{verbatim}
@@ -1022,7 +1021,7 @@ See source file '\inFileName' for licencing and contact information.
 % Thus the individual objects, not the XObject as a whole, will be affected
 % by outer transparency command.
 %
-% As shown in the example, you can reuse the mplibgroup once defined
+% As shown in the example, you can reuse the mplibgroup
 % using the \TeX\ command \cs{usemplibgroup} or
 % the \metapost command |usemplibgroup|.
 % The behavior of these commands is the same as that described \hyperlink{usemplibgroup}{above},
@@ -2769,7 +2768,7 @@ def mplibgraphictext primary t =
 enddef;
 def mplibgraphictext_ (expr t) text rest =
   save fakebold, scale, fillcolor, drawcolor, withfillcolor, withdrawcolor,
-    fb, fc, dc, graphictextpic;
+    fb, fc, dc, graphictextpic, alsoordoublepath;
   picture graphictextpic; graphictextpic := nullpicture;
   numeric fb; string fc, dc; fb:=2; fc:="white"; dc:="black";
   let scale = scaled;
@@ -2777,10 +2776,8 @@ def mplibgraphictext_ (expr t) text rest =
   def fillcolor primary c = hide(fc:=colordecimals c;) enddef;
   def drawcolor primary c = hide(dc:=colordecimals c;) enddef;
   let withfillcolor = fillcolor; let withdrawcolor = drawcolor;
-  addto graphictextpic doublepath origin rest; graphictextpic:=nullpicture;
-  def fakebold  primary c = enddef;
-  let fillcolor = fakebold; let drawcolor = fakebold;
-  let withfillcolor = fillcolor; let withdrawcolor = drawcolor;
+  def alsoordoublepath expr p = if picture p: also else: doublepath fi p enddef;
+  addto graphictextpic alsoordoublepath (origin--cycle) rest; graphictextpic:=nullpicture;
   image(draw runscript("return luamplib.graphictext([===["&t&"]===],"
     & decimal fb &",'"& fc &"','"& dc &"')") rest;)
   endgroup;
@@ -3005,7 +3002,7 @@ primarydef p withshadingmethod m =
       withprescript "sh_transform=yes"
       mplib_with_shade_method (pathpart p, m)
     fi
-  else :
+  elseif path p:
     withprescript "sh_transform=yes"
     mplib_with_shade_method (p, m)
   fi

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -112,7 +112,7 @@ See source file '\inFileName' for licencing and contact information.
   ItalicFont  = {Linux Libertine O Italic},
   SlantedFont = {Linux Libertine O Italic},
 ]{Linux Libertine O}
-\setmonofont[Scale=MatchLowercase,ItalicFont=*]{InconsolataN}
+\setmonofont[Scale=MatchLowercase]{InconsolataN}
 %setsansfont[Ligatures=TeX]{Linux Biolinum O}
 \setsansfont[UprightFont=*Medium,BoldFont=*Heavy,Ligatures=TeX,Scale=MatchLowercase]{Iwona}
 %setmathfont{XITS Math}
@@ -569,7 +569,7 @@ See source file '\inFileName' for licencing and contact information.
 %   BBox info will be added automatically to the PDF\@.
 %   This key is needed for ordinary \metapost figures.
 %   You can change alternative text within \metapost code as well:
-%   |VerbatimTeX| |"\mplibalttext{...}";|
+%   |VerbatimTeX| |"\mplibalttext|\marg{text}|";|
 % \item[\texttt{actualtext=}\meta{text}] starts a |Span| tag implicitly and sets an actualtext from the \meta{text}.
 %   BBox info will not be added.
 %   Horizontal mode is forced by \cs{noindent} or \cs{leavevmode} command
@@ -581,7 +581,7 @@ See source file '\inFileName' for licencing and contact information.
 %   This key is intended for figures which can be represented by a character or
 %   a small sequence of characters.
 %   You can change actualtext within \metapost code as well:
-%   |VerbatimTeX| |"\mplibactualtext{...}";|
+%   |VerbatimTeX| |"\mplibactualtext|\marg{text}|";|
 % \item[\texttt{artifact}] starts an |artifact| MC (marked content).
 %   BBox info will not be added.
 %   This key is intended for decorative figures which have no semantic meaning.
@@ -602,27 +602,30 @@ See source file '\inFileName' for licencing and contact information.
 % \item[\texttt{tag=}\meta{name}] You can choose a tag name, default value being |Figure|.
 %   BBox info will be added automatically to the PDF
 %   unless the value is |artifact|, |text| or |false|.
-%   |tag=false| is a synonym of the |off| option just mentioned.
-% \item[\texttt{correct-BBox=}\meta{dimens}] You can correct the bounding box of the figure
+%   Among these the last one, |tag=false|, is a synonym of the |off| option just mentioned.
+%   For instance, you can set `|tag=Formula,| |alt=|\meta{text}' to get |Formula| structure
+%   with the alternative text.
+% \item[\texttt{correct-BBox=}\meta{dimens}] You can correct the BBox attribute of the figure
 %   with space-separated four dimensional values, which will be added to the
 %   automatically-calculated BBox values.
+%   To draw the bounding box of a figure for checking, you can declare
+%   |\DocumentMetadata|\allowbreak|{debug=BBox}|
+%   after |\DocumentMetadata{tagging=|\allowbreak|on}| setup is completed.
 % \item[\texttt{tagging-setup=}\meta{key-val list}]
 %   This key accepts as its value the list of key-value options mentioned so far.
 % \end{description}
-% To draw the boundingbox of a figure for checking, you can declare |\DocumentMetadata|\allowbreak|{debug=BBox}|
-% after |\DocumentMetadata{tagging=on}| setup is completed.
 %
 % The above options are provided also for \cs{mpfig} and \cs{usemplibgroup} (see \hyperlink{usemplibgroup}{below} \S\,1.2) commands.
 %\begin{verbatim}
-%     \begin{mplibcode}[myInstanceName, alt=figure drawing a circle]
+%     \begin{mplibcode}[myInstanceName, alt=drawing of a circle]
 %     ...
 %     \end{mplibcode}
 %
-%     \mpfig[alt=figure drawing a square box]
+%     \mpfig[alt=drawing of a square box]
 %     ...
 %     \endmpfig
 %
-%     \usemplibgroup[alt=figure drawing a triangle]{...}
+%     \usemplibgroup[alt=drawing of a triangle]{...}
 %
 %     \mppattern{...}           % see below
 %       \mpfig[off]             % do not tag this figure
@@ -5229,6 +5232,7 @@ end
 \tl_new:N \l__luamplib_tag_struct_tl
 \tl_set:Nn\l__luamplib_tag_struct_tl {Figure}
 \bool_new:N \l__luamplib_tag_usetext_bool
+\bool_new:N \g__luamplib_tag_asgroup_bool
 \bool_new:N \l__luamplib_tag_BBox_bool
 \seq_new:N\l__luamplib_tag_bboxcorr_seq
 \bool_new:N\l__luamplib_tag_bboxcorr_bool
@@ -5239,8 +5243,8 @@ end
 \tl_new:N \l__luamplib_BBox_ury_tl
 \msg_new:nnn {luamplib}{figure-text-reuse}
 {
-  textext~box~#1~probably~is~incorrectly~tagged.\\
-  Reusing~a~box~in~text-keyed~figures~is~strongly~discouraged.
+  tex-text~box~#1~probably~is~incorrectly~tagged.\\
+  Reusing~a~box~in~text-mode~figures~is~strongly~discouraged.
 }
 \msg_new:nnn{luamplib}{alt-text-missing}
 {
@@ -5252,6 +5256,7 @@ end
 %    \begin{macrocode}
 \NewSocket{tagsupport/luamplib/textext/begin}{1}
 \NewSocket{tagsupport/luamplib/textext/end}{0}
+\NewSocket{tagsupport/luamplib/textext/put}{2}
 \NewSocketPlug{tagsupport/luamplib/textext/begin}{default}
 {
     \tag_mc_end_push:
@@ -5274,8 +5279,47 @@ end
     \tag_mc_end:
     \tag_mc_begin_pop:n{}
 }
+\NewSocketPlug{tagsupport/luamplib/textext/put}{default}
+{
+    \bool_if:NTF \l__luamplib_tag_usetext_bool
+    {
+      \ResumeTagging{\mplibputtextbox}
+      \tag_mc_end:
+      \cs_if_exist:cTF {luamplib.tagbox.#1}
+      {
+        \bool_gset_false:N \g__luamplib_tag_asgroup_bool
+%    \end{macrocode}
+% TODO: To avoid nested |P|. Not sure this is a bug of tagpdf.
+%    \begin{macrocode}
+\tag_struct_begin:n{tag=NonStruct}
+        \tag_struct_use_num:n {\csname luamplib.tagbox.#1\endcsname}
+        #2
+\tag_struct_end:
+      }
+      {
+        \bool_gset_true:N \g__luamplib_tag_asgroup_bool
+        \cs_if_exist:cF {luamplib.notagbox.#1}
+        {
+          \msg_warning:nnn{luamplib}{figure-text-reuse}{#1}
+        }
+        \tag_mc_begin:n{}
+        \int_set:Nn \l_tmpa_int {#1}
+        \tag_mc_reset_box:N \l_tmpa_int
+        #2
+        \tag_mc_end:
+      }
+      \tag_mc_begin:n{artifact}
+    }
+    {
+      \bool_gset_false:N \g__luamplib_tag_asgroup_bool
+      \int_set:Nn \l_tmpa_int {#1}
+      \tag_mc_reset_box:N \l_tmpa_int
+      #2
+    }
+}
 \AssignSocketPlug{tagsupport/luamplib/textext/begin}{default}
 \AssignSocketPlug{tagsupport/luamplib/textext/end}{default}
+\AssignSocketPlug{tagsupport/luamplib/textext/put}{default}
 \cs_set_nopar:Npn \luamplibtagtextbegin #1
 {
   \bool_if:NTF \l__luamplib_tag_usetext_bool
@@ -5286,7 +5330,7 @@ end
     \tag_if_active:TF
       { \bool_set_true:N \l_tmpa_bool }
       { \bool_set_false:N \l_tmpa_bool }
-    \SuspendTagging{luamplib.textext}
+    \SuspendTagging{\luamplibtagtextbegin}
   }
 }
 \cs_set_nopar:Npn \luamplibtagtextend
@@ -5297,40 +5341,42 @@ end
   }
   {
     \bool_if:NT \l_tmpa_bool
-      { \ResumeTagging{luamplib.textext} }
+      { \ResumeTagging{\luamplibtagtextend} }
   }
 }
 \cs_set_nopar:Npn \mplibputtextbox #1
 {
   \vbox to 0pt{\vss\hbox to 0pt{%
-    \bool_if:NTF \l__luamplib_tag_usetext_bool
-    {
-      \ResumeTagging{luamplib.puttextbox}
-      \tag_mc_end:
-      \cs_if_exist:cTF {luamplib.tagbox.#1}
-      {
-        \tag_struct_use_num:n {\csname luamplib.tagbox.#1\endcsname}
-        \raise\dp#1\copy#1
-      }
-      {
-        \cs_if_exist:cF {luamplib.notagbox.#1}
-        {
-          \msg_warning:nnn{luamplib}{figure-text-reuse}{#1}
-        }
-        \tag_mc_begin:n{}
-        \int_set:Nn \l_tmpa_int {#1}
-        \tag_mc_reset_box:N \l_tmpa_int
-        \raise\dp#1\copy#1
-        \tag_mc_end:
-      }
-      \tag_mc_begin:n{artifact}
-    }
-    {
-      \int_set:Nn \l_tmpa_int {#1}
-      \tag_mc_reset_box:N \l_tmpa_int
-      \raise\dp#1\copy#1
-    }
+%    \end{macrocode}
+% This socket should be always active.
+%    \begin{macrocode}
+    \UseSocket{tagsupport/luamplib/textext/put}{#1}{\raise\dp#1\copy#1}
   \hss}}
+}
+%    \end{macrocode}
+% TODO: Not sure whether asgroup will be tagged correctly.
+%    \begin{macrocode}
+\cs_set_nopar:Npn \luamplibtagasgroupbegin
+{
+  \bool_lazy_and:nnT
+  {\g__luamplib_tag_asgroup_bool}
+  {\l__luamplib_tag_usetext_bool}
+  {
+    \ResumeTagging{\luamplibtagasgroupbegin}
+    \tag_mc_end:
+    \tag_mc_begin:n{}
+  }
+}
+\cs_set_nopar:Npn \luamplibtagasgroupend
+{
+  \bool_lazy_and:nnT
+  {\g__luamplib_tag_asgroup_bool}
+  {\l__luamplib_tag_usetext_bool}
+  {
+    \tag_mc_end:
+    \tag_mc_begin:n{artifact}
+    \SuspendTagging{\luamplibtagasgroupend}
+  }
 }
 %    \end{macrocode}
 % Sockets for environment options
@@ -5388,7 +5434,7 @@ end
 \AssignSocketPlug{tagsupport/luamplib/begin}{figure}
 \AssignSocketPlug{tagsupport/luamplib/end}{figure}
 %    \end{macrocode}
-% A sockets to force horizontal mode upon keys |text| and |actualtext|
+% A sockets to force horizontal mode upon |text|, |actualtext|, and |off|
 %    \begin{macrocode}
 \NewSocket{tagsupport/luamplib/hmode/force}{0}
 \NewSocketPlug{tagsupport/luamplib/hmode/force}{default}
@@ -5433,15 +5479,6 @@ end
 }
 \AssignSocketPlug{tagsupport/luamplib/hmode/force}{default}
 %    \end{macrocode}
-% A sockets for text-keyed figures
-%    \begin{macrocode}
-\NewSocket{tagsupport/luamplib/text/init}{0}
-\NewSocketPlug{tagsupport/luamplib/text/init}{default}
-{
-  \bool_set_true:N \l__luamplib_tag_usetext_bool
-}
-\AssignSocketPlug{tagsupport/luamplib/text/init}{default}
-%    \end{macrocode}
 % Key-value options
 %    \begin{macrocode}
 \keys_define:nn{luamplib/tag}
@@ -5468,7 +5505,7 @@ end
     ,artifact .groups:n = {tagging}
     ,text .code:n =
       {
-        \UseTaggingSocket{luamplib/text/init}
+        \tag_if_active:T { \bool_set_true:N \l__luamplib_tag_usetext_bool }
         \AssignSocketPlug{tagsupport/luamplib/begin}{artifact}
         \AssignSocketPlug{tagsupport/luamplib/end}{artifact}
         \UseTaggingSocket{luamplib/hmode/force}
@@ -5477,7 +5514,7 @@ end
     ,off .code:n =
       {
         \UseTaggingSocket{luamplib/hmode/force}
-        \SuspendTagging{luamplib.tagoff}
+        \SuspendTagging{luamplib/tag/off}
       }
     ,off .groups:n = {tagging}
     ,tag .code:n =
@@ -5511,7 +5548,7 @@ end
 %    \end{macrocode}
 % A socket for BBox attribute
 %    \begin{macrocode}
-\NewSocket{tagsupport/luamplib/bbox}{0}
+\NewSocket{tagsupport/luamplib/bbox}{1}
 \NewSocketPlug{tagsupport/luamplib/bbox}{default}
 {
   \bool_if:NT \l__luamplib_tag_BBox_bool
@@ -5527,17 +5564,17 @@ end
     \tl_set:Ne \l__luamplib_BBox_lly_tl
       {
         \dim_to_decimal_in_bp:n
-        { \property_ref:een {\l__luamplib_BBox_label_tl}{ypos}{0}sp - \dp\mplibscratchbox }
+        { \property_ref:een {\l__luamplib_BBox_label_tl}{ypos}{0}sp - \dp#1 }
       }
     \tl_set:Ne \l__luamplib_BBox_urx_tl
       {
         \dim_to_decimal_in_bp:n
-        { \l__luamplib_BBox_llx_tl bp + \wd\mplibscratchbox }
+        { \l__luamplib_BBox_llx_tl bp + \wd#1 }
       }
     \tl_set:Ne \l__luamplib_BBox_ury_tl
       {
         \dim_to_decimal_in_bp:n
-        { \l__luamplib_BBox_lly_tl bp + \ht\mplibscratchbox + \dp\mplibscratchbox }
+        { \l__luamplib_BBox_lly_tl bp + \ht#1 + \dp#1 }
       }
     \bool_if:NT \l__luamplib_tag_bboxcorr_bool
       {
@@ -5599,7 +5636,7 @@ end
           }
         \use:e
         {
-          \exp_not:N\AddToHookNext{shipout/foreground}
+          \AddToHookNext{shipout/foreground}
           {
             \exp_not:N\int_compare:nNnT
             {\exp_not:N\g_shipout_readonly_int}
@@ -5609,7 +5646,7 @@ end
               \exp_not:N\put
               (\l__luamplib_BBox_llx_tl bp, \dim_eval:n{\l__luamplib_BBox_lly_tl bp -\paperheight})
               {
-                \exp_not:N\opacity_select:n{0.5} \exp_not:N\color_select:n{red}
+                \opacity_select:n{0.5} \color_select:n{red}
                 \exp_not:N\rule
                   {\dim_eval:n {\l__luamplib_BBox_urx_tl bp - \l__luamplib_BBox_llx_tl bp}}
                   {\dim_eval:n {\l__luamplib_BBox_ury_tl bp - \l__luamplib_BBox_lly_tl bp}}
@@ -5661,7 +5698,7 @@ end
     \parindent0pt
     \everypar{}%
     \setbox\mplibscratchbox\vbox\bgroup
-    \SuspendTagging{luamplib.mplibtopdf}% stop tag inside figure
+    \SuspendTagging{\mplibstarttoPDF}
     \noindent
   }
 \cs_set_nopar:Npn \mplibstoptoPDF
@@ -5681,7 +5718,7 @@ end
        \box\mplibscratchbox}%
     \wd\mplibscratchbox\MPwidth
     \ht\mplibscratchbox\MPheight
-    \UseTaggingSocket{luamplib/bbox}
+    \UseTaggingSocket{luamplib/bbox}\mplibscratchbox
     \box\mplibscratchbox
     \UseTaggingSocket{luamplib/end}
     \egroup
@@ -5721,7 +5758,7 @@ end
     \csname luamplib.group.#2\endcsname
     \UseTaggingSocket{luamplib/mplibgroup/end}
     \egroup
-    \UseTaggingSocket{luamplib/bbox}
+    \UseTaggingSocket{luamplib/bbox}\mplibscratchbox
     \unhbox\mplibscratchbox
     \UseTaggingSocket{luamplib/end}
     \egroup

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -585,14 +585,15 @@ See source file '\inFileName' for licencing and contact information.
 % \item[\texttt{artifact}] starts an |artifact| MC (marked content).
 %   BBox info will not be added.
 %   This key is intended for decorative figures which have no semantic meaning.
-% \item[\texttt{text}] starts an |artifact| MC but enables tagging on textext
-%   (the same as |btex| |...| |etex|) boxes.
+% \item[\texttt{text}] starts an |artifact| MC but enables tagging on tex-text boxes
+%   (such as |btex| |...| |etex|, excluding pictures made by |infont| operator).
 %   BBox info will not be added.
 %   Horizontal mode is forced by \cs{noindent} or \cs{leavevmode} command
 %   according to the definition of \cs{prependtomplibbox}.\footnote{%
 %     |text| key also shares the limitation mentioned in the previous footnote.}
-%   This key is intended for figures the meaning of which can be regarded as a text.
-%   Inside |text|-mode figures, reusing textext boxes is strongly discouraged.
+%   This key is intended for figures whose meaning is the sequence of texts in the
+%   tex-text boxes in the order they are drawn in the figure.
+%   Inside |text|-mode figures, reusing tex-text boxes is strongly discouraged.
 % \item[\texttt{off}] Unlike the same key of |picture| environment, tagging is deactivated by this option.
 %   It is another but simpler way to declare the option |tag=false|.
 %   Horizontal mode is forced by \cs{noindent} or \cs{leavevmode} command

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -5198,7 +5198,7 @@ end
 \ifcsname SuspendTagging\endcsname\else\endinput\fi
 \ifcsname ver@tagpdf.sty\endcsname \else
   \ExplSyntaxOn
-  \keys_define:nn{luamplib/notag}
+  \keys_define:nn{luamplib/notagging}
     {
       ,alt          .code:n = { }
       ,actualtext   .code:n = { }
@@ -5215,7 +5215,7 @@ end
   \RenewDocumentCommand\mplibcode{O{}}
     {
       \tl_gset_eq:NN \currentmpinstancename \c_empty_tl
-      \keys_set:ne{luamplib/notag}{#1}
+      \keys_set:ne{luamplib/notagging}{#1}
       \mplibtmptoks{}\ltxdomplibcode
     }
   \ExplSyntaxOff
@@ -5223,7 +5223,6 @@ end
   \let\mplibactualtext \mplibalttext
   \endinput\fi
 \ExplSyntaxOn
-\tl_new:N \l__luamplib_notag_keyval_tl
 \tl_new:N \l__luamplib_tag_envname_tl
 \tl_set:Nn\l__luamplib_tag_envname_tl {mplibcode}
 \tl_new:N \l__luamplib_tag_alt_tl
@@ -5255,10 +5254,10 @@ end
 %    \end{macrocode}
 % Sockets for textext
 %    \begin{macrocode}
-\NewSocket{tagsupport/luamplib/textext/begin}{1}
-\NewSocket{tagsupport/luamplib/textext/end}{0}
-\NewSocket{tagsupport/luamplib/textext/put}{2}
-\NewSocketPlug{tagsupport/luamplib/textext/begin}{default}
+\socket_new:nn{tagsupport/luamplib/textext/begin}{1}
+\socket_new:nn{tagsupport/luamplib/textext/end}{0}
+\socket_new:nn{tagsupport/luamplib/textext/put}{2}
+\socket_new_plug:nnn{tagsupport/luamplib/textext/begin}{default}
 {
     \tag_mc_end_push:
     \tag_mc_begin:n{}
@@ -5267,7 +5266,7 @@ end
     \edef\mystructnum{\tag_get:n{struct_num}}
     \edef\statebeforebox{\inteval{\tag_get:n{struct_counter}+\tag_get:n{mc_counter}}}
 }
-\NewSocketPlug{tagsupport/luamplib/textext/end}{default}
+\socket_new_plug:nnn{tagsupport/luamplib/textext/end}{default}
 {
     \edef\stateafterbox{\inteval{\tag_get:n{struct_counter}+\tag_get:n{mc_counter}}}
     \int_compare:nNnTF
@@ -5280,11 +5279,11 @@ end
     \tag_mc_end:
     \tag_mc_begin_pop:n{}
 }
-\NewSocketPlug{tagsupport/luamplib/textext/put}{default}
+\socket_new_plug:nnn{tagsupport/luamplib/textext/put}{default}
 {
     \bool_if:NTF \l__luamplib_tag_usetext_bool
     {
-      \ResumeTagging{\mplibputtextbox}
+      \tag_resume:n{\mplibputtextbox}
       \tag_mc_end:
       \cs_if_exist:cTF {luamplib.tagbox.#1}
       {
@@ -5318,31 +5317,31 @@ end
       #2
     }
 }
-\AssignSocketPlug{tagsupport/luamplib/textext/begin}{default}
-\AssignSocketPlug{tagsupport/luamplib/textext/end}{default}
-\AssignSocketPlug{tagsupport/luamplib/textext/put}{default}
+\socket_assign_plug:nn{tagsupport/luamplib/textext/begin}{default}
+\socket_assign_plug:nn{tagsupport/luamplib/textext/end}{default}
+\socket_assign_plug:nn{tagsupport/luamplib/textext/put}{default}
 \cs_set_nopar:Npn \luamplibtagtextbegin #1
 {
   \bool_if:NTF \l__luamplib_tag_usetext_bool
   {
-    \UseTaggingSocket{luamplib/textext/begin}{#1}
+    \tag_socket_use:nn{luamplib/textext/begin}{#1}
   }
   {
     \tag_if_active:TF
       { \bool_set_true:N \l_tmpa_bool }
       { \bool_set_false:N \l_tmpa_bool }
-    \SuspendTagging{\luamplibtagtextbegin}
+    \tag_suspend:n{\luamplibtagtextbegin}
   }
 }
 \cs_set_nopar:Npn \luamplibtagtextend
 {
   \bool_if:NTF \l__luamplib_tag_usetext_bool
   {
-    \UseTaggingSocket{luamplib/textext/end}
+    \tag_socket_use:n{luamplib/textext/end}
   }
   {
     \bool_if:NT \l_tmpa_bool
-      { \ResumeTagging{\luamplibtagtextend} }
+      { \tag_resume:n{\luamplibtagtextend} }
   }
 }
 \cs_set_nopar:Npn \mplibputtextbox #1
@@ -5363,7 +5362,7 @@ end
   {\g__luamplib_tag_asgroup_bool}
   {\l__luamplib_tag_usetext_bool}
   {
-    \ResumeTagging{\luamplibtagasgroupbegin}
+    \tag_resume:n{\luamplibtagasgroupbegin}
     \tag_mc_end:
     \tag_mc_begin:n{}
   }
@@ -5376,15 +5375,15 @@ end
   {
     \tag_mc_end:
     \tag_mc_begin:n{artifact}
-    \SuspendTagging{\luamplibtagasgroupend}
+    \tag_suspend:n{\luamplibtagasgroupend}
   }
 }
 %    \end{macrocode}
 % Sockets for environment options
 %    \begin{macrocode}
-\NewSocket{tagsupport/luamplib/begin}{0}
-\NewSocket{tagsupport/luamplib/end}{0}
-\NewSocketPlug{tagsupport/luamplib/begin}{alt}
+\socket_new:nn{tagsupport/luamplib/begin}{0}
+\socket_new:nn{tagsupport/luamplib/end}{0}
+\socket_new_plug:nnn{tagsupport/luamplib/begin}{alt}
 {
     \tag_mc_end_push:
     \tl_if_empty:NT\l__luamplib_tag_alt_tl
@@ -5400,13 +5399,13 @@ end
     }
     \tag_mc_begin:n{}
 }
-\NewSocketPlug{tagsupport/luamplib/end}{alt}
+\socket_new_plug:nnn{tagsupport/luamplib/end}{alt}
 {
     \tag_mc_end:
     \tag_struct_end:
     \tag_mc_begin_pop:n{}
 }
-\NewSocketPlug{tagsupport/luamplib/begin}{actualtext}
+\socket_new_plug:nnn{tagsupport/luamplib/begin}{actualtext}
 {
     \tag_mc_end_push:
     \tag_struct_begin:n
@@ -5416,29 +5415,29 @@ end
     }
     \tag_mc_begin:n{}
 }
-\NewSocketPlug{tagsupport/luamplib/end}{actualtext}
+\socket_new_plug:nnn{tagsupport/luamplib/end}{actualtext}
 {
     \tag_mc_end:
     \tag_struct_end:
     \tag_mc_begin_pop:n{}
 }
-\NewSocketPlug{tagsupport/luamplib/begin}{artifact}
+\socket_new_plug:nnn{tagsupport/luamplib/begin}{artifact}
 {
     \tag_mc_end_push:
     \tag_mc_begin:n{artifact}
 }
-\NewSocketPlug{tagsupport/luamplib/end}{artifact}
+\socket_new_plug:nnn{tagsupport/luamplib/end}{artifact}
 {
     \tag_mc_end:
     \tag_mc_begin_pop:n{}
 }
-\AssignSocketPlug{tagsupport/luamplib/begin}{alt}
-\AssignSocketPlug{tagsupport/luamplib/end}{alt}
+\socket_assign_plug:nn{tagsupport/luamplib/begin}{alt}
+\socket_assign_plug:nn{tagsupport/luamplib/end}{alt}
 %    \end{macrocode}
 % A socket for BBox attribute
 %    \begin{macrocode}
-\NewSocket{tagsupport/luamplib/bbox}{1}
-\NewSocketPlug{tagsupport/luamplib/bbox}{default}
+\socket_new:nn{tagsupport/luamplib/bbox}{1}
+\socket_new_plug:nnn{tagsupport/luamplib/bbox}{default}
 {
   \bool_if:NT \l__luamplib_tag_BBox_bool
   {
@@ -5546,7 +5545,7 @@ end
       }
   }
 }
-\AssignSocketPlug{tagsupport/luamplib/bbox}{default}
+\socket_assign_plug:nn{tagsupport/luamplib/bbox}{default}
 %    \end{macrocode}
 % A sockets to force horizontal mode upon |text|, |actualtext|, and |off|
 %    \begin{macrocode}
@@ -5590,29 +5589,29 @@ end
     }
   }
 }
-\NewSocket{tagsupport/luamplib/starting}{0}
-\NewSocketPlug{tagsupport/luamplib/starting}{default}{}
-\NewSocketPlug{tagsupport/luamplib/starting}{actualtext}
+\socket_new:nn{tagsupport/luamplib/starting}{0}
+\socket_new_plug:nnn{tagsupport/luamplib/starting}{default}{}
+\socket_new_plug:nnn{tagsupport/luamplib/starting}{actualtext}
 {
   \__luamplib_tag_hmode_force:
 }
-\NewSocketPlug{tagsupport/luamplib/starting}{text}
+\socket_new_plug:nnn{tagsupport/luamplib/starting}{text}
 {
   \bool_set_true:N \l__luamplib_tag_usetext_bool
   \__luamplib_tag_hmode_force:
 }
-\NewSocketPlug{tagsupport/luamplib/starting}{off}
+\socket_new_plug:nnn{tagsupport/luamplib/starting}{off}
 {
   \__luamplib_tag_hmode_force:
-  \SuspendTagging{luamplib/tag/off}
+  \tag_suspend:n{luamplib/tag/off}
 }
-\AssignSocketPlug{tagsupport/luamplib/starting}{default}
+\socket_assign_plug:nn{tagsupport/luamplib/starting}{default}
 %    \end{macrocode}
 % Sockets for mplibgroup
 %    \begin{macrocode}
-\NewSocket{tagsupport/luamplib/mplibgroup/begin}{0}
-\NewSocket{tagsupport/luamplib/mplibgroup/end}{0}
-\NewSocketPlug{tagsupport/luamplib/mplibgroup/begin}{default}
+\socket_new:nn{tagsupport/luamplib/mplibgroup/begin}{0}
+\socket_new:nn{tagsupport/luamplib/mplibgroup/end}{0}
+\socket_new_plug:nnn{tagsupport/luamplib/mplibgroup/begin}{default}
 {
     \bool_if:NT \l__luamplib_tag_usetext_bool
     {
@@ -5620,7 +5619,7 @@ end
       \tag_mc_begin:n{}
     }
 }
-\NewSocketPlug{tagsupport/luamplib/mplibgroup/end}{default}
+\socket_new_plug:nnn{tagsupport/luamplib/mplibgroup/end}{default}
 {
     \bool_if:NT \l__luamplib_tag_usetext_bool
     {
@@ -5628,8 +5627,8 @@ end
       \tag_mc_begin:n{artifact}
     }
 }
-\AssignSocketPlug{tagsupport/luamplib/mplibgroup/begin}{default}
-\AssignSocketPlug{tagsupport/luamplib/mplibgroup/end}{default}
+\socket_assign_plug:nn{tagsupport/luamplib/mplibgroup/begin}{default}
+\socket_assign_plug:nn{tagsupport/luamplib/mplibgroup/end}{default}
 %    \end{macrocode}
 % Key-value options
 %    \begin{macrocode}
@@ -5639,32 +5638,32 @@ end
       {
         \bool_set_true:N \l__luamplib_tag_BBox_bool
         \tl_set:Ne\l__luamplib_tag_alt_tl{\text_purify:n{#1}}
-        \AssignSocketPlug{tagsupport/luamplib/begin}{alt}
-        \AssignSocketPlug{tagsupport/luamplib/end}{alt}
-        \AssignSocketPlug{tagsupport/luamplib/starting}{default}
+        \socket_assign_plug:nn{tagsupport/luamplib/begin}{alt}
+        \socket_assign_plug:nn{tagsupport/luamplib/end}{alt}
+        \socket_assign_plug:nn{tagsupport/luamplib/starting}{default}
       }
     ,actualtext .code:n =
       {
         \tl_set:Ne\l__luamplib_tag_actual_tl{\text_purify:n{#1}}
-        \AssignSocketPlug{tagsupport/luamplib/begin}{actualtext}
-        \AssignSocketPlug{tagsupport/luamplib/end}{actualtext}
-        \AssignSocketPlug{tagsupport/luamplib/starting}{actualtext}
+        \socket_assign_plug:nn{tagsupport/luamplib/begin}{actualtext}
+        \socket_assign_plug:nn{tagsupport/luamplib/end}{actualtext}
+        \socket_assign_plug:nn{tagsupport/luamplib/starting}{actualtext}
       }
     ,artifact .code:n =
       {
-        \AssignSocketPlug{tagsupport/luamplib/begin}{artifact}
-        \AssignSocketPlug{tagsupport/luamplib/end}{artifact}
-        \AssignSocketPlug{tagsupport/luamplib/starting}{default}
+        \socket_assign_plug:nn{tagsupport/luamplib/begin}{artifact}
+        \socket_assign_plug:nn{tagsupport/luamplib/end}{artifact}
+        \socket_assign_plug:nn{tagsupport/luamplib/starting}{default}
       }
     ,text .code:n =
       {
-        \AssignSocketPlug{tagsupport/luamplib/begin}{artifact}
-        \AssignSocketPlug{tagsupport/luamplib/end}{artifact}
-        \AssignSocketPlug{tagsupport/luamplib/starting}{text}
+        \socket_assign_plug:nn{tagsupport/luamplib/begin}{artifact}
+        \socket_assign_plug:nn{tagsupport/luamplib/end}{artifact}
+        \socket_assign_plug:nn{tagsupport/luamplib/starting}{text}
       }
     ,off .code:n =
       {
-        \AssignSocketPlug{tagsupport/luamplib/starting}{off}
+        \socket_assign_plug:nn{tagsupport/luamplib/starting}{off}
       }
     ,tag .code:n =
       {
@@ -5689,7 +5688,7 @@ end
         \keys_set_known:nn {luamplib/tag} {#1}
       }
   }
-\keys_define:nn {luamplib/notag}
+\keys_define:nn {luamplib/instance}
   {
     ,instance .code:n = { \tl_gset:Nn \currentmpinstancename {#1} }
     ,instancename .meta:n = { instance = {#1} }
@@ -5702,7 +5701,7 @@ end
   {
     \prependtomplibbox
     \hbox dir TLT\bgroup
-    \UseTaggingSocket{luamplib/begin}
+    \tag_socket_use:n{luamplib/begin}
     \xdef\MPllx{#1}\xdef\MPlly{#2}%
     \xdef\MPurx{#3}\xdef\MPury{#4}%
     \xdef\MPwidth{\the\dimexpr#3bp-#1bp\relax}%
@@ -5712,7 +5711,7 @@ end
     \parindent0pt
     \everypar{}%
     \setbox\mplibscratchbox\vbox\bgroup
-    \SuspendTagging{\mplibstarttoPDF}
+    \tag_suspend:n{\mplibstarttoPDF}
     \noindent
   }
 \cs_set_nopar:Npn \mplibstoptoPDF
@@ -5732,20 +5731,20 @@ end
        \box\mplibscratchbox}%
     \wd\mplibscratchbox\MPwidth
     \ht\mplibscratchbox\MPheight
-    \UseTaggingSocket{luamplib/bbox}\mplibscratchbox
+    \tag_socket_use:nn{luamplib/bbox}\mplibscratchbox
     \box\mplibscratchbox
-    \UseTaggingSocket{luamplib/end}
+    \tag_socket_use:n{luamplib/end}
     \egroup
   }
 \RenewDocumentCommand\mplibcode{O{}}
   {
     \tl_set:Nn \l__luamplib_tag_envname_tl {mplibcode}
     \tl_gset_eq:NN \currentmpinstancename \c_empty_tl
-    \keys_set_known:neN {luamplib/tag} {#1} \l__luamplib_notag_keyval_tl
-    \keys_set:nV {luamplib/notag} \l__luamplib_notag_keyval_tl
+    \keys_set_known:neN {luamplib/tag} {#1} \l_tmpa_tl
+    \keys_set:nV {luamplib/instance} \l_tmpa_tl
     \tl_if_empty:NF \currentmpinstancename
       { \tl_set:Nn\l__luamplib_tag_alt_dflt_tl {metapost~figure~\currentmpinstancename} }
-    \UseTaggingSocket{luamplib/starting}
+    \tag_socket_use:n{luamplib/starting}
     \mplibtmptoks{}\ltxdomplibcode
   }
 \RenewDocumentCommand\mpfig{s O{}}
@@ -5755,11 +5754,11 @@ end
     {\mplibprempfig *}
     {
       \tl_set:Nn \l__luamplib_tag_envname_tl {mpfig}
-      \keys_set_known:neN {luamplib/tag} {#2} \l__luamplib_notag_keyval_tl
-      \keys_set:nV {luamplib/notag} \l__luamplib_notag_keyval_tl
+      \keys_set_known:neN {luamplib/tag} {#2} \l_tmpa_tl
+      \keys_set:nV {luamplib/instance} \l_tmpa_tl
       \tl_if_empty:NF \mpfiginstancename
         { \tl_set:Nn\l__luamplib_tag_alt_dflt_tl {metapost~figure~\mpfiginstancename} }
-      \UseTaggingSocket{luamplib/starting}
+      \tag_socket_use:n{luamplib/starting}
       \mplibmainmpfig
     }
   }
@@ -5767,20 +5766,20 @@ end
   {
     \begingroup
     \tl_set:Nn \l__luamplib_tag_envname_tl {usemplibgroup}
-    \keys_set_known:neN {luamplib/tag} {#1} \l__luamplib_notag_keyval_tl
-    \keys_set:nV {luamplib/notag} \l__luamplib_notag_keyval_tl
+    \keys_set_known:neN {luamplib/tag} {#1} \l_tmpa_tl
+    \keys_set:nV {luamplib/instance} \l_tmpa_tl
     \tl_set:Nn\l__luamplib_tag_alt_dflt_tl {metapost~figure~#2}
-    \UseTaggingSocket{luamplib/starting}
+    \tag_socket_use:n{luamplib/starting}
     \prependtomplibbox\hbox dir TLT\bgroup
-    \UseTaggingSocket{luamplib/begin}
+    \tag_socket_use:n{luamplib/begin}
     \setbox\mplibscratchbox\hbox\bgroup
-    \UseTaggingSocket{luamplib/mplibgroup/begin}
+    \tag_socket_use:n{luamplib/mplibgroup/begin}
     \csname luamplib.group.#2\endcsname
-    \UseTaggingSocket{luamplib/mplibgroup/end}
+    \tag_socket_use:n{luamplib/mplibgroup/end}
     \egroup
-    \UseTaggingSocket{luamplib/bbox}\mplibscratchbox
+    \tag_socket_use:nn{luamplib/bbox}\mplibscratchbox
     \unhbox\mplibscratchbox
-    \UseTaggingSocket{luamplib/end}
+    \tag_socket_use:n{luamplib/end}
     \egroup
     \endgroup
   }

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -85,7 +85,7 @@ See source file '\inFileName' for licencing and contact information.
 %<*driver>
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesFile{luamplib.drv}%
-  [2025/03/20 v2.37.2 Interface for using the mplib library]%
+  [2025/05/15 v2.37.3 Interface for using the mplib library]%
 \documentclass{ltxdoc}
 \usepackage{metalogo,multicol,xspace}
 \usepackage[x11names]{xcolor}
@@ -155,7 +155,7 @@ See source file '\inFileName' for licencing and contact information.
 % \author{Hans Hagen, Taco Hoekwater, Elie Roux, Philipp Gesang and Kim Dohyun\\
 % Current Maintainer: Kim Dohyun\\
 % Support: \url{https://github.com/lualatex/luamplib}}
-% \date{2025/03/20 v2.37.2}
+% \date{2025/05/15 v2.37.3}
 %
 % \maketitle
 %
@@ -559,6 +559,7 @@ See source file '\inFileName' for licencing and contact information.
 % The code related to this functionality is currently in experimental stage, not guaranteeing backward compatibility.
 % Available optional keys are similar to those of the \LaTeX's |picture| environment
 % (|texdoc| |latex-lab-graphic|).
+% The default tagging mode is the |alt| key with |Figure| structure.
 % \begin{description}
 % \item[\texttt{alt=}\meta{text}] starts a |Figure| tag by default and
 %   sets an alternate text of the figure from the \meta{text}.
@@ -616,7 +617,12 @@ See source file '\inFileName' for licencing and contact information.
 %   This key accepts as its value the list of key-value options mentioned so far.
 % \end{description}
 %
-% The above options are provided also for \cs{mpfig} and \cs{usemplibgroup} (see \hyperlink{usemplibgroup}{below} \S\,1.2) commands.
+% You can set these tagging options anywhere in the document by declaring
+% \cs{SetKeys}\allowbreak |[luamplib/tagging]|\allowbreak \marg{key-val list},
+% which will affect \pkg{luamplib} figures thereafter in the scope.
+%
+% And these options are provided also for \cs{mpfig} and \cs{usemplibgroup}
+% (see \hyperlink{usemplibgroup}{below} \S\,1.2) commands.
 %\begin{verbatim}
 %     \begin{mplibcode}[myInstanceName, alt=drawing of a circle]
 %     ...
@@ -1254,8 +1260,8 @@ See source file '\inFileName' for licencing and contact information.
 
 luatexbase.provides_module {
   name          = "luamplib",
-  version       = "2.37.2",
-  date          = "2025/03/20",
+  version       = "2.37.3",
+  date          = "2025/05/15",
   description   = "Lua package to typeset Metapost with LuaTeX's MPLib.",
 }
 
@@ -4685,7 +4691,7 @@ end
 %    \begin{macrocode}
   \NeedsTeXFormat{LaTeX2e}
   \ProvidesPackage{luamplib}
-    [2025/03/20 v2.37.2 mplib package for LuaTeX]
+    [2025/05/15 v2.37.3 mplib package for LuaTeX]
 \fi
 \ifdefined\newluafunction\else
   \input ltluatex
@@ -5298,7 +5304,9 @@ end
 }
 \socket_new_plug:nnn{tagsupport/luamplib/textext/put}{default}
 {
-  \bool_if:NTF \l__luamplib_tag_usetext_bool
+  \bool_lazy_and:nnTF
+  { \l__luamplib_tag_usetext_bool }
+  { \cs_if_free_p:c {luamplib.notaggedbox.#1} }
   {
     \tag_resume:n{\mplibputtextbox}
     \tag_mc_end:
@@ -5345,7 +5353,6 @@ end
 \cs_set_nopar:Npn \mplibputtextbox #1
 {
   \vbox to 0pt{\vss\hbox to 0pt{
-    \cs_if_exist:cT {luamplib.notaggedbox.#1}{ \bool_set_false:N \l__luamplib_tag_usetext_bool }
     \socket_use:nnn{tagsupport/luamplib/textext/put}{#1}{\raise\dp#1\copy#1}
   \hss}}
 }
@@ -5564,7 +5571,7 @@ end
 }
 %    \end{macrocode}
 % A socket for tagging init, so that we can declare
-% |\keys_set:nn{luamplib/tagging}{...}| anywhere in the document.
+% |\SetKeys[luamplib/tagging]{...}| anywhere in the document.
 %    \begin{macrocode}
 \socket_new:nn{tagsupport/luamplib/figure/init}{0}
 \socket_new_plug:nnn{tagsupport/luamplib/figure/init}{alt}

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -585,7 +585,7 @@ See source file '\inFileName' for licencing and contact information.
 %   (such as |btex| |...| |etex|, excluding pictures made by |infont| operator).\footnote{\relax
 %     The key |text| also shares the limitation mentioned in the previous footnote.}
 %   BBox info will not be added.
-%   This key is intended for figures whose meaning is the sequence of texts in the
+%   This key is intended for figures the meaning of which is the sequence of texts in the
 %   tex-text boxes in the order they are drawn in the figure.
 %   Inside |text|-mode figures, reusing tex-text boxes is strongly discouraged.
 % \item[\texttt{off}] Given this key, nothing will be tagged by \pkg{luamplib}.
@@ -5266,13 +5266,8 @@ end
     \tag_mc_end:
     \cs_if_exist:cTF {luamplib.tagbox.#1}
     {
-%    \end{macrocode}
-% TODO: To avoid nested |P|. Not sure this is a bug of tagpdf.
-%    \begin{macrocode}
-      \tag_struct_begin:n{tag=NonStruct}
       \tag_struct_use_num:n {\csname luamplib.tagbox.#1\endcsname}
       #2
-      \tag_struct_end:
     }
     {
       \msg_warning:nnn{luamplib}{figure-text-reuse}{#1}
@@ -5558,6 +5553,10 @@ end
   \socket_assign_plug:nn{tagsupport/luamplib/figure/end}{artifact}
   \socket_assign_plug:nn{tagsupport/luamplib/figure/bbox}{noop}
   \__luamplib_tag_pseudo_para_begin:
+%    \end{macrocode}
+% TODO: To avoid nested |P|. Not sure this is a bug of tagpdf.
+%    \begin{macrocode}
+  \cs_set_nopar:Npn \prependtomplibbox {\tag_struct_begin:n{tag=NonStruct,stash} \tag_struct_end:}
 }
 \socket_new_plug:nnn{tagsupport/luamplib/figure/init}{off}
 {

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -5229,8 +5229,8 @@ end
 \msg_new:nnn {luamplib}{figure-text-reuse}
 {
   tex-text~box~#1~probably~is~incorrectly~tagged.\\
-  Check~the~resulting~PDF.~
-  Reusing~a~box~in~text-mode~figures~is~strongly~discouraged.
+  Reusing~a~box~from~non-text~mode~is~strongly~discouraged.~
+  Check~the~resulting~PDF.
 }
 \msg_new:nnn{luamplib}{alt-text-missing}
 {
@@ -5251,7 +5251,7 @@ end
 %    \end{macrocode}
 % TODO: We force a structure. If not, |a| and |b| in |btex a $x$ b etex| are not tagged.
 %    \begin{macrocode}
-    \tag_mc_begin:n{tag=text}
+    \tag_mc_begin:n{}
 }
 \socket_new_plug:nnn{tagsupport/luamplib/textext/end}{default}
 {
@@ -5286,6 +5286,10 @@ end
 }
 \cs_set_nopar:Npn \luamplibtagtextbegin #1
 {
+%    \end{macrocode}
+% TODO: we test |text| mode here.
+% If the socket is used for all modes, we can get a lot of structure-has-no-parent warning.
+%    \begin{macrocode}
   \bool_if:NTF \l__luamplib_tag_usetext_bool
   {
     \tag_socket_use:nn{luamplib/textext/begin}{#1}

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -578,32 +578,28 @@ See source file '\inFileName' for licencing and contact information.
 %   a small sequence of characters.
 %   You can change the actual text within \metapost code as well:
 %   |VerbatimTeX| |"\mplibactualtext|\marg{text}|";|
-% \item[\texttt{artifact}] starts an |artifact| MC (marked content).
+% \item[\texttt{artifact}] starts an |Artifact| MC (marked content).
 %   BBox info will not be added.
 %   This key is intended for decorative figures which have no semantic meaning.
-% \item[\texttt{text}] starts an |artifact| MC but enables tagging on tex-text boxes
+% \item[\texttt{text}] starts an |Artifact| MC but enables tagging on tex-text boxes
 %   (such as |btex| |...| |etex|, excluding pictures made by |infont| operator).\footnote{\relax
-%     The |text| key also shares the limitation mentioned in the previous footnote.}
+%     The key |text| also shares the limitation mentioned in the previous footnote.}
 %   BBox info will not be added.
 %   This key is intended for figures whose meaning is the sequence of texts in the
 %   tex-text boxes in the order they are drawn in the figure.
 %   Inside |text|-mode figures, reusing tex-text boxes is strongly discouraged.
 % \item[\texttt{off}] Given this key, \pkg{luamplib} does nothing about tagging.
-%   It is up to you to embrace the \metapost figure by proper tagging commands.
-% \item[\texttt{tag=}\meta{name}] You can choose a tag name, default value being |Figure|.
+% \item[\texttt{tag=}\meta{name}] You can choose a tag name, default value being |Figure|.\relax
+%   \footnote{When the value, however, is |false|, tagging is deactivated,
+%     and the result is not much different from the |off| key.
+%     But the option |tag=false| also shares the limitation mentioned in the previous footnote.}
 %   For instance, you can set `|tag=Formula,| |alt=|\meta{text}' to get
-%   a |Formula| structure with its alternate text.\footnote{Beware that this bypasses
-%     \LaTeX's regular math formula tagging.}
-%   However, when the value is |false|, tagging is deactivated for the figure.\footnote{\relax
-%     In horizontal mode, the figure will be tagged as a |text| (same as |P|) element
-%     even with |tag=false| option.
-%     Upon this option, therefore, \cs{mplibnoforcehmode}
-%     (see \hyperlink{mplibforcehmode}{above} on this command) is forced internally.
-%     Again, users should not change horizontal/vertical mode by |verbatimtex| command.}
+%   a |Formula| element with its alternate text.\footnote{Beware that this bypasses
+%     \LaTeX's regular math formula tagging, for which the |text| key is needed.}
 % \item[\texttt{adjust-BBox=}\meta{dimens}] You can correct the BBox attribute of the figure
 %   by space-separated four dimensional values, which will be added to the
 %   automatically calculated BBox values.
-%   To draw the bounding box for checking with half transparent red color, you can add
+%   To draw the bounding box for checking with half-transparent red color, you can add
 %   |debug=|\allowbreak|BBox| to the argument of \cs{DocumentMetadata} command.
 % \item[\texttt{tagging-setup=}\meta{key-val list}]
 %   This key accepts as its value the list of key-value options mentioned so far.
@@ -622,7 +618,7 @@ See source file '\inFileName' for licencing and contact information.
 %     \usemplibgroup[alt=drawing of a triangle]{...}
 %
 %     \mppattern{...}           % see below
-%       \mpfig[tag=false]       % do not tag this figure
+%       \mpfig[off]             % do not tag this figure
 %       ...
 %       \endmpfig
 %     \endmppattern
@@ -5595,10 +5591,7 @@ end
 }
 \socket_new_plug:nnn{tagsupport/luamplib/init}{false}
 {
-%    \end{macrocode}
-% As we deactivate tagging, switching to horizontal mode raises an error.
-%    \begin{macrocode}
-  \mplibnoforcehmode
+  \prependtomplibbox \mplibnoforcehmode
   \tag_suspend:n{luamplib/tag/false}
 }
 \socket_assign_plug:nn{tagsupport/luamplib/init}{alt}
@@ -5625,11 +5618,11 @@ end
         \str_case:nnF {#1}
           {
             {false}    { \socket_assign_plug:nn{tagsupport/luamplib/init}{false} }
-            {text}     { \keys_set:nn {luamplib/tag} {text} }
             {artifact} { \keys_set:nn {luamplib/tag} {artifact} }
           }
           {
             \tl_set:Nn\l__luamplib_tag_struct_tl{#1}
+            \socket_assign_plug:nn{tagsupport/luamplib/init}{alt}
           }
       }
     ,adjust-BBox .code:n =

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -196,7 +196,7 @@ See source file '\inFileName' for licencing and contact information.
 %   When these \TeX\ commands are found in |verbatimtex ... etex|, the entire code will be
 %   ignored.
 %   The treatment of |verbatimtex| command has changed a lot since v2.20:
-%   see \hyperlink{mpliblegacybehavior}{below \S\,1.1}.
+%   see \hyperlink{mpliblegacybehavior}{below} \S\,1.1.
 %
 % \item in the past,
 %   the package required PDF mode in order to have some output.
@@ -210,11 +210,13 @@ See source file '\inFileName' for licencing and contact information.
 % \subsection{\TeX}
 %
 % \subsubsection{\cs{mplibforcehmode}}
+%   \hypertarget{mplibforcehmode}{}\relax
 %   When this macro is declared, every \metapost figure box will be
 %   typeset in horizontal mode, so \cs{centering}, \cs{raggedleft} etc
 %   will have effects. \cs{mplibnoforcehmode}, being default, reverts this
-%   setting. (Actually these commands redefine \cs{prependtomplibbox}; you
-%   can redefine this command with anything suitable before a box.)
+%   setting.\footnote{Actually these commands redefine \cs{prependtomplibbox}. So you
+%     can redefine this command with anything suitable before a box.
+%     But see \hyperlink{taggedPDF}{below} on Tagged PDF. }
 %
 % \subsubsection{\cs{everymplib\{...\}}, \cs{everyendmplib\{...\}}}
 %   \cs{everymplib} and \cs{everyendmplib} redefine
@@ -241,7 +243,7 @@ See source file '\inFileName' for licencing and contact information.
 %   At least, however, transparency (actually opacity), shading (gradient colors) and transparency group
 %   are fully supported,
 %   and outlinetext is supported by our own alternative |mpliboutlinetext|
-%   (see \hyperlink{mpliboutlinetext}{below \S\,1.2}).
+%   (see \hyperlink{mpliboutlinetext}{below} \S\,1.2).
 %   You can try other effects as well, though we did not fully tested their proper functioning.
 %
 % \begin{description}
@@ -305,7 +307,10 @@ See source file '\inFileName' for licencing and contact information.
 %   following \metapost figure box.  In this way,
 %   each figure box can be freely moved horizontally or vertically.
 %   Also, a box number can be assigned to a figure box, allowing it to be
-%   reused later.
+%   reused later.\footnote{But
+%     the recommended way to reuse a figure is using \cs{mplibgroup} command.
+%     See \hyperlink{mplibgroupendmplibgroup}{below} \S\,1.2.
+%   }
 %\begin{verbatim}
 %     \mplibcode
 %     verbatimtex \moveright 3cm etex; beginfig(0); ... endfig;
@@ -549,39 +554,53 @@ See source file '\inFileName' for licencing and contact information.
 %   or \cs{mplibcodeinherit} are suitable for going into this file.
 %
 % \subsubsection{Tagged PDF}
+%   \hypertarget{taggedPDF}{}\relax
 % When \pkg{tagpdf} package is loaded and activated, |mplibcode| environment accepts additional options for tagged PDF\@.
 % The code related to this functionality is currently in experimental stage, not guaranteeing backward compatibility.
 % Like the \LaTeX's |picture| environment,
-% available optional keys are |tag|, |alt|, |actualtext|, |artifact|, |debug| and |correct-BBox|
+% available optional keys are |tag|, |alt|, |actualtext|, |artifact|, |text|, |off|, |debug| and |correct-BBox|
 % (|texdoc| |latex-lab-graphic|).
-% Additionally, luamplib provides its own |text| key.
 % \begin{description}
 % \item[|tag=...|] You can choose a tag name, default value being |Figure|.
 %   BBox info will be added automatically to the PDF
-%   unless the value is |text| or |false|.
+%   unless the value is |artifact|, |text|, |off| or |false|.
 %   When the value is |false|, tagging is deactivated.
-% \item[|debug|] draws bounding box of the figure for checking, which you can correct
-%   by |correct-BBox| key with space-separated four dimen values.
 % \item[|alt=...|] sets an alternative text of the figure as given.
 %   This key is needed for ordinary \metapost figures.
-%   You can give alternative text within \metapost code as well:
+%   You can change alternative text within \metapost code as well:
 %   |VerbatimTeX| |"\mplibalttext{...}";|
-% \item[|actualtext=...|] starts a |Span| tag implicitly and sets an actual text as given.
-%   Horizontal mode is forced by \cs{noindent} command. BBox info will not be added.
+% \item[|actualtext=...|] starts a |Span| tag implicitly and sets an actualtext as given.
+%   BBox info will not be added.
+%   Horizontal mode is forced by \cs{noindent} or \cs{leavevmode} command
+%   according to the definition of \cs{prependtomplibbox}.\footnote{%
+%     It is not recommended to personally redefine \cs{prependtomplibbox}.
+%     Apart from using \cs{mplibforcehmode} or \cs{mplibnoforcehmode},
+%     the redefinition might be incompatible with |actualtext| key.
+%     See \hyperlink{mplibforcehmode}{above} on these commands. }
 %   This key is intended for figures which can be represented by a character or
 %   a small sequence of characters.
-%   You can give actual text within \metapost code as well:
+%   You can change actualtext within \metapost code as well:
 %   |VerbatimTeX| |"\mplibactualtext{...}";|
 % \item[|artifact|] starts an |artifact| MC (marked content).
 %   BBox info will not be added.
 %   This key is intended for decorative figures which have no semantic quality.
 % \item[|text|] starts an |artifact| MC and enables tagging on textext
 %   (the same as |btex| |...| |etex|) boxes.
-%   Horizontal mode is forced by \cs{noindent} command. BBox info will not be added.
+%   BBox info will not be added.
+%   Horizontal mode is forced by \cs{noindent} or \cs{leavevmode} command
+%   according to the definition of \cs{prependtomplibbox}.\footnote{%
+%     |text| key also shares the limitation mentioned in the previous footnote.}
 %   This key is intended for figures made mostly of textext boxes.
 %   Inside text-keyed figures, reusing textext boxes is strongly discouraged.
+% \item[|off|] luamplib does nothing about tagging.
+%   |mplibcode| remains transprent to the surrounding tagging commands.
+% \item[|debug|] draws the bounding box of the figure for checking.
+% \item[|correct-BBox=...|] You can correct the bounding box of the figure
+%   with space-separated four dimen values.
+% \item[|tagging-setup=...|]
+%   This key accepts as its value the list of key-value options mentioned so far.
 % \end{description}
-% These keys are provided also for \cs{mpfig} and \cs{usemplibgroup} (see \hyperlink{usemplibgroup}{below}) commands.
+% The above keys are provided also for \cs{mpfig} and \cs{usemplibgroup} (see \hyperlink{usemplibgroup}{below} \S\,1.2) commands.
 %\begin{verbatim}
 %     \begin{mplibcode}[myInstanceName, alt=figure drawing a circle]
 %     ...
@@ -608,7 +627,7 @@ See source file '\inFileName' for licencing and contact information.
 %
 % \subsubsection{\texttt{mplibdimen ...}, \texttt{mplibcolor ...}}
 %   These are \metapost interfaces for the \TeX\ commands
-%   \cs{mpdim} and \cs{mpcolor} (see \hyperlink{mpdim}{above}). For example,
+%   \cs{mpdim} and \cs{mpcolor} (see \hyperlink{mpdim}{above} \S\,1.1). For example,
 %   |mplibdimen "\linewidth"| is basically the same as \cs{mpdim\{\cs{linewidth}\}}, and
 %   |mplibcolor "red!50"| is basically the same as \cs{mpcolor\{red!50\}}.
 %   The difference is that these \metapost operators can also be used in external |.mp| files,
@@ -656,9 +675,10 @@ See source file '\inFileName' for licencing and contact information.
 %   such as the vertical writing in Chinese or Japanese.
 %   However, because the implementation is quite different from others,
 %   there are some limitations such that you can't
-%   apply shading (gradient colors) to the text with |withshademethod| from \emph{metafun}.
-%   (But this limitation is now lifted by the introduction of |withshadingmethod|.
-%   See \hyperlink{luamplibshading}{below}.)
+%   apply shading (gradient colors) to the text with |withshademethod| from
+%   \emph{metafun}.\footnote{But
+%   this limitation is now lifted by the introduction of |withshadingmethod|.
+%   See \hyperlink{luamplibshading}{below}.}
 %   Again,
 %   in DVI mode, \pkg{unicode-math} package is needed for math formula,
 %   as we cannot embolden type1 fonts in DVI mode.
@@ -970,6 +990,7 @@ See source file '\inFileName' for licencing and contact information.
 % colors will have effects on the uncolored objects in the group.
 %
 % \subsubsection{\cs{mplibgroup\{...\} ...} \cs{endmplibgroup}}
+%   \hypertarget{mplibgroupendmplibgroup}{}\relax
 % These \TeX\ macros are described here in this subsection, as they are
 % deeply related to the |asgroup| operator.
 % Users can define a transparency group or a normal \emph{form XObject}
@@ -1044,8 +1065,8 @@ See source file '\inFileName' for licencing and contact information.
 % \subsubsection{\texttt{... withshadingmethod ...}}
 %   \hypertarget{luamplibshading}{}\relax
 %   The syntax is exactly the same as \emph{metafun}'s new shading method (|texdoc metafun| \S\,8.3.3), except that
-%   the `\textcolor{red}{|shade|}' contained in each and every macro name has changed to
-%   `\textcolor{red}{|shading|}' in luamplib: for instance, while |withshademethod| is
+%   the `|shade|' contained in each and every macro name has changed to
+%   `|shading|' in luamplib: for instance, while |withshademethod| is
 %   a macro name which only works with \emph{metafun} format,
 %   the equivalent provided by luamplib, |withshadingmethod|, works with \emph{plain} as well.
 %   Other differences to the \emph{metafun}'s and some cautions are:
@@ -3005,7 +3026,7 @@ primarydef p withshadingmethod m =
       withprescript "sh_transform=yes"
       mplib_with_shade_method (pathpart p, m)
     fi
-  elseif path p:
+  else :
     withprescript "sh_transform=yes"
     mplib_with_shade_method (p, m)
   fi
@@ -4727,12 +4748,10 @@ end
 %    \begin{macrocode}
 \protected\def\usemplibgroup#1#{\usemplibgroupmain}
 \def\usemplibgroupmain#1{%
-  \mplibstarttousemplibgroup
+  \prependtomplibbox\hbox dir TLT\bgroup
   \csname luamplib.group.#1\endcsname
-  \mplibstoptousemplibgroup
+  \egroup
 }
-\def\mplibstarttousemplibgroup{\prependtomplibbox\hbox dir TLT\bgroup}
-\def\mplibstoptousemplibgroup{\egroup}
 \protected\def\mplibgroup#1{%
   \begingroup
   \def\MPllx{0}\def\MPlly{0}%
@@ -5187,12 +5206,9 @@ end
   \let\mplibalttext \luamplibtagtextbegin
   \let\mplibactualtext \mplibalttext
   \endinput\fi
-\let\mplibstarttoPDForiginal\mplibstarttoPDF
-\let\mplibstoptoPDForiginal\mplibstoptoPDF
-\let\mplibputtextboxoriginal\mplibputtextbox
-\let\mplibstarttousemplibgrouporiginal\mplibstarttousemplibgroup
-\let\mplibstoptousemplibgrouporiginal\mplibstoptousemplibgroup
 \ExplSyntaxOn
+\tl_new:N \l__luamplib_tag_envname_tl
+\tl_set:Nn\l__luamplib_tag_envname_tl {mplibcode}
 \tl_new:N \l__luamplib_tag_alt_tl
 \tl_new:N \l__luamplib_tag_alt_dflt_tl
 \tl_set:Nn\l__luamplib_tag_alt_dflt_tl {metapost~figure}
@@ -5201,7 +5217,6 @@ end
 \tl_set:Nn\l__luamplib_tag_struct_tl {Figure}
 \bool_new:N \l__luamplib_tag_usetext_bool
 \bool_new:N \l__luamplib_tag_BBox_bool
-\bool_set_true:N \l__luamplib_tag_BBox_bool
 \seq_new:N\l__luamplib_tag_bboxcorr_seq
 \bool_new:N\l__luamplib_tag_bboxcorr_bool
 \bool_new:N \l__luamplib_tag_debug_bool
@@ -5210,16 +5225,50 @@ end
 \tl_new:N \l__luamplib_BBox_lly_tl
 \tl_new:N \l__luamplib_BBox_urx_tl
 \tl_new:N \l__luamplib_BBox_ury_tl
-\cs_set_nopar:Npn \luamplibtagtextbegin #1
+\msg_new:nnn {luamplib}{figure-text-reuse}
 {
-  \bool_if:NTF \l__luamplib_tag_usetext_bool
-  {
+  textext~box~#1~probably~is~incorrectly~tagged.\\
+  Reusing~a~box~in~text-keyed~figures~is~strongly~discouraged.
+}
+\msg_new:nnn{luamplib}{alt-text-missing}
+{
+  Alternative~text~for~#1~is~missing.\\
+  Using~the~default~value~'#2'~instead.
+}
+%    \end{macrocode}
+% Sockets for textext
+%    \begin{macrocode}
+\NewSocket{tagsupport/luamplib/textext/begin}{1}
+\NewSocket{tagsupport/luamplib/textext/end}{0}
+\NewSocketPlug{tagsupport/luamplib/textext/begin}{default}
+{
     \tag_mc_end_push:
     \tag_mc_begin:n{}
     \tag_struct_begin:n{tag=NonStruct,stash}
     \def\myboxnum{#1}
     \edef\mystructnum{\tag_get:n{struct_num}}
     \edef\statebeforebox{\inteval{\tag_get:n{struct_counter}+\tag_get:n{mc_counter}}}
+}
+\NewSocketPlug{tagsupport/luamplib/textext/end}{default}
+{
+    \edef\stateafterbox{\inteval{\tag_get:n{struct_counter}+\tag_get:n{mc_counter}}}
+    \int_compare:nNnTF
+      {\stateafterbox}
+      =
+      {\statebeforebox}
+      { \cs_gset_nopar:cpe {luamplib.notagbox.\myboxnum} {\mystructnum} }
+      { \cs_gset_nopar:cpe {luamplib.tagbox.\myboxnum} {\mystructnum} }
+    \tag_struct_end:
+    \tag_mc_end:
+    \tag_mc_begin_pop:n{}
+}
+\AssignSocketPlug{tagsupport/luamplib/textext/begin}{default}
+\AssignSocketPlug{tagsupport/luamplib/textext/end}{default}
+\cs_set_nopar:Npn \luamplibtagtextbegin #1
+{
+  \bool_if:NTF \l__luamplib_tag_usetext_bool
+  {
+    \UseTaggingSocket{luamplib/textext/begin}{#1}
   }
   {
     \tag_if_active:TF
@@ -5232,28 +5281,12 @@ end
 {
   \bool_if:NTF \l__luamplib_tag_usetext_bool
   {
-    \edef\stateafterbox{\inteval{\tag_get:n{struct_counter}+\tag_get:n{mc_counter}}}
-    \tag_if_active:T {
-      \int_compare:nNnTF
-      {\stateafterbox}
-      =
-      {\statebeforebox}
-      { \cs_gset_nopar:cpe {luamplib.notagbox.\myboxnum} {\mystructnum} }
-      { \cs_gset_nopar:cpe {luamplib.tagbox.\myboxnum} {\mystructnum} }
-    }
-    \tag_struct_end:
-    \tag_mc_end:
-    \tag_mc_begin_pop:n{}
+    \UseTaggingSocket{luamplib/textext/end}
   }
   {
     \bool_if:NT \l_tmpa_bool
       { \ResumeTagging{luamplib.textext} }
   }
-}
-\msg_new:nnn {luamplib}{figure-text-reuse}
-{
-  textext~box~#1~probably~is~incorrectly~tagged.\\
-  Reusing~a~box~in~text-keyed~figures~is~strongly~discouraged.
 }
 \cs_set_nopar:Npn \mplibputtextbox #1
 {
@@ -5287,14 +5320,18 @@ end
     }
   \hss}}
 }
-\cs_new_nopar:Npn \__luamplib_tagging_begin_figure:
+%    \end{macrocode}
+% Sockets for environment options
+%    \begin{macrocode}
+\NewSocket{tagsupport/luamplib/begin}{0}
+\NewSocket{tagsupport/luamplib/end}{0}
+\NewSocketPlug{tagsupport/luamplib/begin}{figure}
 {
-  \tag_if_active:T
-  {
     \tag_mc_end_push:
     \tl_if_empty:NT\l__luamplib_tag_alt_tl
     {
-      \msg_warning:nne{luamplib}{alt-text-missing}{\l__luamplib_tag_alt_dflt_tl}
+      \msg_warning:nnee{luamplib}{alt-text-missing}
+                       {\l__luamplib_tag_envname_tl}{\l__luamplib_tag_alt_dflt_tl}
       \tl_set:Ne\l__luamplib_tag_alt_tl {\l__luamplib_tag_alt_dflt_tl}
     }
     \tag_struct_begin:n
@@ -5303,21 +5340,15 @@ end
       alt=\l__luamplib_tag_alt_tl,
     }
     \tag_mc_begin:n{}
-  }
 }
-\cs_new_nopar:Npn \__luamplib_tagging_end_figure:
+\NewSocketPlug{tagsupport/luamplib/end}{figure}
 {
-  \tag_if_active:T
-  {
     \tag_mc_end:
     \tag_struct_end:
     \tag_mc_begin_pop:n{}
-  }
 }
-\cs_new_nopar:Npn \__luamplib_tagging_begin_actualtext:
+\NewSocketPlug{tagsupport/luamplib/begin}{actualtext}
 {
-  \tag_if_active:T
-  {
     \tag_mc_end_push:
     \tag_struct_begin:n
     {
@@ -5325,94 +5356,169 @@ end
       actualtext=\l__luamplib_tag_actual_tl,
     }
     \tag_mc_begin:n{}
-  }
 }
-\cs_set_eq:NN \__luamplib_tagging_end_actualtext: \__luamplib_tagging_end_figure:
-\cs_new_nopar:Npn \__luamplib_tagging_begin_artifact:
+\NewSocketPlug{tagsupport/luamplib/end}{actualtext}
 {
-  \tag_if_active:T
-  {
+    \tag_mc_end:
+    \tag_struct_end:
+    \tag_mc_begin_pop:n{}
+}
+\NewSocketPlug{tagsupport/luamplib/begin}{artifact}
+{
     \tag_mc_end_push:
     \tag_mc_begin:n{artifact}
-  }
 }
-\cs_new_nopar:Npn \__luamplib_tagging_end_artifact:
+\NewSocketPlug{tagsupport/luamplib/end}{artifact}
 {
-  \tag_if_active:T
-  {
     \tag_mc_end:
     \tag_mc_begin_pop:n{}
+}
+\NewSocketPlug{tagsupport/luamplib/begin}{transparent}
+{
+}
+\NewSocketPlug{tagsupport/luamplib/end}{transparent}
+{
+}
+\AssignSocketPlug{tagsupport/luamplib/begin}{figure}
+\AssignSocketPlug{tagsupport/luamplib/end}{figure}
+%    \end{macrocode}
+% A sockets to force horizontal mode upon keys |text| and |actualtext|
+%    \begin{macrocode}
+\NewSocket{tagsupport/luamplib/hmode/force}{0}
+\NewSocketPlug{tagsupport/luamplib/hmode/force}{default}
+{
+  \mode_if_vertical:T
+  {
+    \cs_if_eq:NNTF \prependtomplibbox \relax
+    {
+      \noindent
+      \aftergroup \par
+    }
+    {
+      \bool_lazy_any:nTF
+      {
+        { \cs_if_eq_p:NN \prependtomplibbox \leavevmode }
+        { \cs_if_eq_p:NN \prependtomplibbox \noindent }
+        { \cs_if_eq_p:NN \prependtomplibbox \mode_leave_vertical: }
+      }
+      { \prependtomplibbox }
+      {
+        \str_set:Ne \l_tmpa_str {\cs_meaning:N \prependtomplibbox}
+        \clist_set:Nn \l_tmpa_clist
+          {\unhbox \voidb@x,\noindent,\mode_leave_vertical:,\tex_indent:D,\indent}
+        \bool_set_false:N \l_tmpa_bool
+        \clist_map_inline:Nn \l_tmpa_clist
+          {
+            \str_if_in:NnT \l_tmpa_str {##1}
+            {
+              ##1
+              \bool_set_true:N \l_tmpa_bool
+              \clist_map_break:
+             }
+          }
+        \bool_if:NF \l_tmpa_bool
+        {
+          \noindent         % prone to an error!
+          \aftergroup \par
+        }
+      }
+    }
   }
 }
-\cs_set_eq:NN \luamplibtaggingbegin \__luamplib_tagging_begin_figure:
-\cs_set_eq:NN \luamplibtaggingend \__luamplib_tagging_end_figure:
-\keys_define:nn{luamplib/tag}
+\AssignSocketPlug{tagsupport/luamplib/hmode/force}{default}
+%    \end{macrocode}
+% A sockets for text-keyed figures
+%    \begin{macrocode}
+\NewSocket{tagsupport/luamplib/text/init}{0}
+\NewSocketPlug{tagsupport/luamplib/text/init}{default}
+{
+  \bool_set_true:N \l__luamplib_tag_usetext_bool
+}
+\AssignSocketPlug{tagsupport/luamplib/text/init}{default}
+%    \end{macrocode}
+% Key-value options
+%    \begin{macrocode}
+\keys_define:nn{tag/luamplib}
   {
     ,alt .code:n =
       {
+        \bool_set_true:N \l__luamplib_tag_BBox_bool
         \tl_set:Ne\l__luamplib_tag_alt_tl{\text_purify:n{#1}}
       }
+    ,alt .groups:n = {tagging}
     ,actualtext .code:n =
       {
-        \bool_set_false:N \l__luamplib_tag_BBox_bool
         \tl_set:Ne\l__luamplib_tag_actual_tl{\text_purify:n{#1}}
-        \cs_set_eq:NN \luamplibtaggingbegin \__luamplib_tagging_begin_actualtext:
-        \cs_set_eq:NN \luamplibtaggingend \__luamplib_tagging_end_actualtext:
-        \tag_if_active:T {\noindent}
+        \AssignSocketPlug{tagsupport/luamplib/begin}{actualtext}
+        \AssignSocketPlug{tagsupport/luamplib/end}{actualtext}
+        \UseTaggingSocket{luamplib/hmode/force}
       }
+    ,actualtext .groups:n = {tagging}
     ,artifact .code:n =
       {
-        \bool_set_false:N \l__luamplib_tag_BBox_bool
-        \cs_set_eq:NN \luamplibtaggingbegin \__luamplib_tagging_begin_artifact:
-        \cs_set_eq:NN \luamplibtaggingend \__luamplib_tagging_end_artifact:
+        \AssignSocketPlug{tagsupport/luamplib/begin}{artifact}
+        \AssignSocketPlug{tagsupport/luamplib/end}{artifact}
       }
+    ,artifact .groups:n = {tagging}
     ,text .code:n =
       {
-        \bool_set_false:N \l__luamplib_tag_BBox_bool
-        \bool_set_true:N  \l__luamplib_tag_usetext_bool
-        \cs_set_eq:NN \luamplibtaggingbegin \__luamplib_tagging_begin_artifact:
-        \cs_set_eq:NN \luamplibtaggingend \__luamplib_tagging_end_artifact:
-        \tag_if_active:T {\noindent}
+        \UseTaggingSocket{luamplib/text/init}
+        \AssignSocketPlug{tagsupport/luamplib/begin}{artifact}
+        \AssignSocketPlug{tagsupport/luamplib/end}{artifact}
+        \UseTaggingSocket{luamplib/hmode/force}
       }
+    ,text .groups:n = {tagging}
+    ,off .code:n =
+      {
+        \AssignSocketPlug{tagsupport/luamplib/begin}{transparent}
+        \AssignSocketPlug{tagsupport/luamplib/end}{transparent}
+      }
+    ,off .groups:n = {tagging}
     ,tag .code:n =
       {
         \str_case:nnF {#1}
           {
+            {artifact}
+            { \keys_set_known:nn {tag/luamplib} {artifact} }
             {text}
-            {
-              \bool_set_false:N \l__luamplib_tag_BBox_bool
-              \bool_set_true:N  \l__luamplib_tag_usetext_bool
-              \cs_set_eq:NN \luamplibtaggingbegin \__luamplib_tagging_begin_artifact:
-              \cs_set_eq:NN \luamplibtaggingend \__luamplib_tagging_end_artifact:
-              \tag_if_active:T {\noindent}
-            }
+            { \keys_set_known:nn {tag/luamplib} {text} }
+            {off}
+            { \keys_set_known:nn {tag/luamplib} {off} }
             {false}
-            {
-              \SuspendTagging{luamplib.tagfalse}
-            }
+            { \SuspendTagging{luamplib.tagfalse} }
           }
           {
+            \bool_set_true:N \l__luamplib_tag_BBox_bool
             \tl_set:Nn\l__luamplib_tag_struct_tl{#1}
           }
       }
+    ,tag .groups:n = {tagging}
     ,correct-BBox .code:n =
       {
         \bool_set_true:N \l__luamplib_tag_bboxcorr_bool
         \seq_set_split:Nnn \l__luamplib_tag_bboxcorr_seq{~}{#1~0pt~0pt~0pt~0pt}
       }
+    ,correct-BBox .groups:n = {tagging}
     ,debug .code:n =
       { \bool_set_true:N \l__luamplib_tag_debug_bool }
+    ,debug .groups:n = {tagging}
+    ,tagging-setup .code:n =
+      {
+        \keys_set_groups:nnn {tag/luamplib} {tagging} {#1}
+      }
     ,instance .code:n =
       { \tl_gset:Nn \currentmpinstancename {#1} }
     ,instancename .meta:n = { instance = {#1} }
     ,unknown .code:n =
       { \tl_gset:Ne \currentmpinstancename {\l_keys_key_str} }
   }
-\cs_new_nopar:Npn \luamplibtaggingBBox
+%    \end{macrocode}
+% A socket for BBox attribute
+%    \begin{macrocode}
+\NewSocket{tagsupport/luamplib/bbox}{0}
+\NewSocketPlug{tagsupport/luamplib/bbox}{default}
 {
-  \bool_lazy_and:nnT
-  {\tag_if_active_p:}
-  {\l__luamplib_tag_BBox_bool}
+  \bool_if:NT \l__luamplib_tag_BBox_bool
   {
     \tl_set:Ne \l__luamplib_BBox_label_tl {luamplib.BBox.\tag_get:n{struct_num}}
     \tex_savepos:D
@@ -5476,22 +5582,20 @@ end
             }
           }
       }
-    \prop_gput:cne
-      { g__tag_struct_\tag_get:n{struct_num}_prop }
-      {A}
+    \tag_struct_gput:ene {\tag_get:n{struct_num}} {attribute}
       {
-        << /O /Layout /BBox [
+        /O /Layout /BBox [
           \l__luamplib_BBox_llx_tl\c_space_tl
           \l__luamplib_BBox_lly_tl\c_space_tl
           \l__luamplib_BBox_urx_tl\c_space_tl
           \l__luamplib_BBox_ury_tl
-        ] >>
+        ]
       }
     \bool_if:NT \l__luamplib_tag_debug_bool
       {
         \iow_log:e
           {
-            luamplib/tag/debug:~BBox~of~structure~\tag_get:n{struct_num}~is~
+            tag/luamplib~debug:~BBox~of~structure~\tag_get:n{struct_num}~is~
             \l__luamplib_BBox_llx_tl\c_space_tl
             \l__luamplib_BBox_lly_tl\c_space_tl
             \l__luamplib_BBox_urx_tl\c_space_tl
@@ -5520,51 +5624,38 @@ end
       }
   }
 }
-\cs_set_nopar:Npn \luamplibtagasgroupbegin
+\AssignSocketPlug{tagsupport/luamplib/bbox}{default}
+%    \end{macrocode}
+% Sockets for mplibgroup
+%    \begin{macrocode}
+\NewSocket{tagsupport/luamplib/mplibgroup/begin}{0}
+\NewSocket{tagsupport/luamplib/mplibgroup/end}{0}
+\NewSocketPlug{tagsupport/luamplib/mplibgroup/begin}{default}
 {
-  \bool_if:NT \l__luamplib_tag_usetext_bool
-  {
-    \ResumeTagging{luamplib.asgroup}
-    \tag_mc_begin:n{}
-  }
+    \bool_if:NT \l__luamplib_tag_usetext_bool
+    {
+      \tag_mc_end:
+      \tag_mc_begin:n{}
+    }
 }
-\cs_set_nopar:Npn \luamplibtagasgroupend
+\NewSocketPlug{tagsupport/luamplib/mplibgroup/end}{default}
 {
-  \bool_if:NT \l__luamplib_tag_usetext_bool
-  {
-    \tag_mc_end:
-    \SuspendTagging{luamplib.asgroup}
-  }
+    \bool_if:NT \l__luamplib_tag_usetext_bool
+    {
+      \tag_mc_end:
+      \tag_mc_begin:n{artifact}
+    }
 }
-\cs_set_nopar:Npn \mplibstarttousemplibgroup
-{
-  \prependtomplibbox\hbox dir TLT\bgroup
-  \luamplibtaggingbegin
-  \setbox\mplibscratchbox\hbox\bgroup
-  \bool_if:NT \l__luamplib_tag_usetext_bool
-  {
-    \tag_mc_end:
-    \tag_mc_begin:n{}
-  }
-}
-\cs_set_nopar:Npn \mplibstoptousemplibgroup
-{
-  \bool_if:NT \l__luamplib_tag_usetext_bool
-  {
-    \tag_mc_end:
-    \tag_mc_begin:n{artifact}
-  }
-  \egroup
-  \luamplibtaggingBBox
-  \unhbox\mplibscratchbox
-  \luamplibtaggingend
-  \egroup
-}
+\AssignSocketPlug{tagsupport/luamplib/mplibgroup/begin}{default}
+\AssignSocketPlug{tagsupport/luamplib/mplibgroup/end}{default}
+%    \end{macrocode}
+% Redefine our macros
+%    \begin{macrocode}
 \cs_set_nopar:Npn \mplibstarttoPDF #1 #2 #3 #4
   {
     \prependtomplibbox
     \hbox dir TLT\bgroup
-    \luamplibtaggingbegin % begin tagging
+    \UseTaggingSocket{luamplib/begin}
     \xdef\MPllx{#1}\xdef\MPlly{#2}%
     \xdef\MPurx{#3}\xdef\MPury{#4}%
     \xdef\MPwidth{\the\dimexpr#3bp-#1bp\relax}%
@@ -5594,20 +5685,16 @@ end
        \box\mplibscratchbox}%
     \wd\mplibscratchbox\MPwidth
     \ht\mplibscratchbox\MPheight
-    \luamplibtaggingBBox % BBox
+    \UseTaggingSocket{luamplib/bbox}
     \box\mplibscratchbox
-    \luamplibtaggingend % end tagging
+    \UseTaggingSocket{luamplib/end}
     \egroup
   }
 \RenewDocumentCommand\mplibcode{O{}}
   {
-    \msg_set:nnn {luamplib}{alt-text-missing}
-    {
-      Alternative~text~for~mplibcode~is~missing.\\
-      Using~the~default~value~'##1'~instead.
-    }
+    \tl_set:Nn \l__luamplib_tag_envname_tl {mplibcode}
     \tl_gset_eq:NN \currentmpinstancename \c_empty_tl
-    \keys_set:ne{luamplib/tag}{#1}
+    \keys_set:ne{tag/luamplib}{#1}
     \tl_if_empty:NF \currentmpinstancename
       { \tl_set:Nn\l__luamplib_tag_alt_dflt_tl {metapost~figure~\currentmpinstancename} }
     \mplibtmptoks{}\ltxdomplibcode
@@ -5618,12 +5705,8 @@ end
     \IfBooleanTF{#1}
     {\mplibprempfig *}
     {
-      \msg_set:nnn {luamplib}{alt-text-missing}
-      {
-        Alternative~text~for~mpfig~is~missing.\\
-        Using~the~default~value~'##1'~instead.
-      }
-      \keys_set:ne{luamplib/tag}{#2}
+      \tl_set:Nn \l__luamplib_tag_envname_tl {mpfig}
+      \keys_set:ne{tag/luamplib}{#2}
       \tl_if_empty:NF \mpfiginstancename
         { \tl_set:Nn\l__luamplib_tag_alt_dflt_tl {metapost~figure~\mpfiginstancename} }
       \mplibmainmpfig
@@ -5632,18 +5715,25 @@ end
 \RenewDocumentCommand\usemplibgroup{O{} m}
   {
     \begingroup
-    \msg_set:nnn {luamplib}{alt-text-missing}
-    {
-      Alternative~text~for~usemplibgroup~is~missing.\\
-      Using~the~default~value~'##1'~instead.
-    }
-    \keys_set:ne{luamplib/tag}{#1}
+    \tl_set:Nn \l__luamplib_tag_envname_tl {usemplibgroup}
+    \keys_set:ne{tag/luamplib}{#1}
     \tl_set:Nn\l__luamplib_tag_alt_dflt_tl {metapost~figure~#2}
-    \mplibstarttousemplibgroup
+    \prependtomplibbox\hbox dir TLT\bgroup
+    \UseTaggingSocket{luamplib/begin}
+    \setbox\mplibscratchbox\hbox\bgroup
+    \UseTaggingSocket{luamplib/mplibgroup/begin}
     \csname luamplib.group.#2\endcsname
-    \mplibstoptousemplibgroup
+    \UseTaggingSocket{luamplib/mplibgroup/end}
+    \egroup
+    \UseTaggingSocket{luamplib/bbox}
+    \unhbox\mplibscratchbox
+    \UseTaggingSocket{luamplib/end}
+    \egroup
     \endgroup
   }
+%    \end{macrocode}
+% Allow setting alt/actual text within \metapost code
+%    \begin{macrocode}
 \cs_new_nopar:Npn \mplibalttext #1
 {
   \tl_set:Ne \l__luamplib_tag_alt_tl {\text_purify:n{#1}}

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -4128,7 +4128,7 @@ local function do_preobj_GRP (object, prescript)
       trgroup[v] = true
     end
     trgroup.bbox = prescript.mplibgroupbbox:explode":"
-    put2output[[\begingroup\setbox\mplibscratchbox\hbox\bgroup]]
+    put2output[[\begingroup\setbox\mplibscratchbox\hbox\bgroup\luamplibtagasgroupinit]]
   elseif grstate == "stop" then
     local llx,lly,urx,ury = tableunpack(trgroup.bbox)
     put2output(tableconcat{
@@ -5181,6 +5181,7 @@ end
 %    \begin{macrocode}
 \def\luamplibtagtextbegin#1{}
 \let\luamplibtagtextend\relax
+\let\luamplibtagasgroupinit\relax
 \let\luamplibtagasgroupbegin\relax
 \let\luamplibtagasgroupend\relax
 \ifcsname SuspendTagging\endcsname\else\endinput\fi
@@ -5330,26 +5331,32 @@ end
 }
 %    \end{macrocode}
 % TODO: Not sure whether asgroup will be tagged correctly.
-%\begin{verbatim}
-%    \cs_set_nopar:Npn \luamplibtagasgroupbegin
-%    {
-%      \bool_if:NT \l__luamplib_tag_usetext_bool
-%      {
-%        \tag_resume:n{\luamplibtagasgroupbegin}
-%        \tag_mc_end:
-%        \tag_mc_begin:n{}
-%      }
-%    }
-%    \cs_set_nopar:Npn \luamplibtagasgroupend
-%    {
-%      \bool_if:NT \l__luamplib_tag_usetext_bool
-%      {
-%        \tag_mc_end:
-%        \tag_mc_begin:n{artifact}
-%        \tag_suspend:n{\luamplibtagasgroupend}
-%      }
-%    }
-%\end{verbatim}
+%       At least, this will raise a warning;
+%       but how can we tease out whether a tex-text box is for asgroup or not?
+%    \begin{macrocode}
+\cs_set_nopar:Npn \luamplibtagasgroupinit
+{
+  \bool_set_false:N \l__luamplib_tag_usetext_bool
+}
+\cs_set_nopar:Npn \luamplibtagasgroupbegin
+{
+  \bool_if:NT \l__luamplib_tag_usetext_bool
+  {
+    \tag_resume:n{\luamplibtagasgroupbegin}
+    \tag_mc_end:
+    \tag_mc_begin:n{}
+  }
+}
+\cs_set_nopar:Npn \luamplibtagasgroupend
+{
+  \bool_if:NT \l__luamplib_tag_usetext_bool
+  {
+    \tag_mc_end:
+    \tag_mc_begin:n{artifact}
+    \tag_suspend:n{\luamplibtagasgroupend}
+  }
+}
+%    \end{macrocode}
 % Sockets for mplibgroup
 %    \begin{macrocode}
 \socket_new:nn{tagsupport/luamplib/mplibgroup/begin}{0}
@@ -5375,9 +5382,9 @@ end
 %    \end{macrocode}
 % Sockets for main process
 %    \begin{macrocode}
-\socket_new:nn{tagsupport/luamplib/begin}{0}
-\socket_new:nn{tagsupport/luamplib/end}{0}
-\socket_new_plug:nnn{tagsupport/luamplib/begin}{alt}
+\socket_new:nn{tagsupport/luamplib/figure/begin}{0}
+\socket_new:nn{tagsupport/luamplib/figure/end}{0}
+\socket_new_plug:nnn{tagsupport/luamplib/figure/begin}{alt}
 {
     \tag_mc_end_push:
     \tl_if_empty:NT\l__luamplib_tag_alt_tl
@@ -5393,14 +5400,14 @@ end
     }
     \tag_mc_begin:n{}
 }
-\socket_new_plug:nnn{tagsupport/luamplib/end}{alt}
+\socket_new_plug:nnn{tagsupport/luamplib/figure/end}{alt}
 {
     \tl_use:N \l__luamplib_tag_bbox_draw_tl
     \tag_mc_end:
     \tag_struct_end:
     \tag_mc_begin_pop:n{}
 }
-\socket_new_plug:nnn{tagsupport/luamplib/begin}{actualtext}
+\socket_new_plug:nnn{tagsupport/luamplib/figure/begin}{actualtext}
 {
     \tag_mc_end_push:
     \tag_struct_begin:n
@@ -5410,18 +5417,18 @@ end
     }
     \tag_mc_begin:n{}
 }
-\socket_new_plug:nnn{tagsupport/luamplib/end}{actualtext}
+\socket_new_plug:nnn{tagsupport/luamplib/figure/end}{actualtext}
 {
     \tag_mc_end:
     \tag_struct_end:
     \tag_mc_begin_pop:n{}
 }
-\socket_new_plug:nnn{tagsupport/luamplib/begin}{artifact}
+\socket_new_plug:nnn{tagsupport/luamplib/figure/begin}{artifact}
 {
     \tag_mc_end_push:
     \tag_mc_begin:n{artifact}
 }
-\socket_new_plug:nnn{tagsupport/luamplib/end}{artifact}
+\socket_new_plug:nnn{tagsupport/luamplib/figure/end}{artifact}
 {
     \tag_mc_end:
     \tag_mc_begin_pop:n{}
@@ -5429,8 +5436,8 @@ end
 %    \end{macrocode}
 % A socket for BBox attribute
 %    \begin{macrocode}
-\socket_new:nn{tagsupport/luamplib/bbox}{1}
-\socket_new_plug:nnn{tagsupport/luamplib/bbox}{alt}
+\socket_new:nn{tagsupport/luamplib/figure/bbox}{1}
+\socket_new_plug:nnn{tagsupport/luamplib/figure/bbox}{alt}
 {
     \tl_set:Ne \l__luamplib_BBox_label_tl {luamplib.BBox.\tag_get:n{struct_num}}
     \tex_savepos:D
@@ -5507,7 +5514,7 @@ end
       {
         \iow_log:e
           {
-            luamplib/tag~debug:~BBox~of~structure~\tag_get:n{struct_num}~is~
+            luamplib/tagging~debug:~BBox~of~structure~\tag_get:n{struct_num}~is~
             \l__luamplib_BBox_llx_tl\c_space_tl
             \l__luamplib_BBox_lly_tl\c_space_tl
             \l__luamplib_BBox_urx_tl\c_space_tl
@@ -5553,69 +5560,69 @@ end
 %    \end{macrocode}
 % A socket for tagging init
 %    \begin{macrocode}
-\socket_new:nn{tagsupport/luamplib/init}{0}
-\socket_new_plug:nnn{tagsupport/luamplib/init}{alt}
+\socket_new:nn{tagsupport/luamplib/figure/init}{0}
+\socket_new_plug:nnn{tagsupport/luamplib/figure/init}{alt}
 {
-  \socket_assign_plug:nn{tagsupport/luamplib/begin}{alt}
-  \socket_assign_plug:nn{tagsupport/luamplib/end}{alt}
-  \socket_assign_plug:nn{tagsupport/luamplib/bbox}{alt}
+  \socket_assign_plug:nn{tagsupport/luamplib/figure/begin}{alt}
+  \socket_assign_plug:nn{tagsupport/luamplib/figure/end}{alt}
+  \socket_assign_plug:nn{tagsupport/luamplib/figure/bbox}{alt}
 }
-\socket_new_plug:nnn{tagsupport/luamplib/init}{actualtext}
+\socket_new_plug:nnn{tagsupport/luamplib/figure/init}{actualtext}
 {
-  \socket_assign_plug:nn{tagsupport/luamplib/begin}{actualtext}
-  \socket_assign_plug:nn{tagsupport/luamplib/end}{actualtext}
-  \socket_assign_plug:nn{tagsupport/luamplib/bbox}{noop}
+  \socket_assign_plug:nn{tagsupport/luamplib/figure/begin}{actualtext}
+  \socket_assign_plug:nn{tagsupport/luamplib/figure/end}{actualtext}
+  \socket_assign_plug:nn{tagsupport/luamplib/figure/bbox}{noop}
   \__luamplib_tag_pseudo_para_begin:
 }
-\socket_new_plug:nnn{tagsupport/luamplib/init}{artifact}
+\socket_new_plug:nnn{tagsupport/luamplib/figure/init}{artifact}
 {
-  \socket_assign_plug:nn{tagsupport/luamplib/begin}{artifact}
-  \socket_assign_plug:nn{tagsupport/luamplib/end}{artifact}
-  \socket_assign_plug:nn{tagsupport/luamplib/bbox}{noop}
+  \socket_assign_plug:nn{tagsupport/luamplib/figure/begin}{artifact}
+  \socket_assign_plug:nn{tagsupport/luamplib/figure/end}{artifact}
+  \socket_assign_plug:nn{tagsupport/luamplib/figure/bbox}{noop}
 }
-\socket_new_plug:nnn{tagsupport/luamplib/init}{text}
+\socket_new_plug:nnn{tagsupport/luamplib/figure/init}{text}
 {
   \bool_set_true:N \l__luamplib_tag_usetext_bool
-  \socket_assign_plug:nn{tagsupport/luamplib/begin}{artifact}
-  \socket_assign_plug:nn{tagsupport/luamplib/end}{artifact}
-  \socket_assign_plug:nn{tagsupport/luamplib/bbox}{noop}
+  \socket_assign_plug:nn{tagsupport/luamplib/figure/begin}{artifact}
+  \socket_assign_plug:nn{tagsupport/luamplib/figure/end}{artifact}
+  \socket_assign_plug:nn{tagsupport/luamplib/figure/bbox}{noop}
   \__luamplib_tag_pseudo_para_begin:
 }
-\socket_new_plug:nnn{tagsupport/luamplib/init}{off}
+\socket_new_plug:nnn{tagsupport/luamplib/figure/init}{off}
 {
-  \socket_assign_plug:nn{tagsupport/luamplib/begin}{noop}
-  \socket_assign_plug:nn{tagsupport/luamplib/end}{noop}
-  \socket_assign_plug:nn{tagsupport/luamplib/bbox}{noop}
+  \socket_assign_plug:nn{tagsupport/luamplib/figure/begin}{noop}
+  \socket_assign_plug:nn{tagsupport/luamplib/figure/end}{noop}
+  \socket_assign_plug:nn{tagsupport/luamplib/figure/bbox}{noop}
 }
-\socket_assign_plug:nn{tagsupport/luamplib/init}{alt}
+\socket_assign_plug:nn{tagsupport/luamplib/figure/init}{alt}
 %    \end{macrocode}
 % Key-value options
 %    \begin{macrocode}
-\keys_define:nn{luamplib/tag}
+\keys_define:nn{luamplib/tagging}
   {
     ,alt .code:n =
       {
         \tl_set:Ne\l__luamplib_tag_alt_tl{\text_purify:n{#1}}
-        \socket_assign_plug:nn{tagsupport/luamplib/init}{alt}
+        \socket_assign_plug:nn{tagsupport/luamplib/figure/init}{alt}
       }
     ,actualtext .code:n =
       {
         \tl_set:Ne\l__luamplib_tag_actual_tl{\text_purify:n{#1}}
-        \socket_assign_plug:nn{tagsupport/luamplib/init}{actualtext}
+        \socket_assign_plug:nn{tagsupport/luamplib/figure/init}{actualtext}
       }
-    ,artifact .code:n = { \socket_assign_plug:nn{tagsupport/luamplib/init}{artifact} }
-    ,text     .code:n = { \socket_assign_plug:nn{tagsupport/luamplib/init}{text} }
-    ,off      .code:n = { \socket_assign_plug:nn{tagsupport/luamplib/init}{off} }
+    ,artifact .code:n = { \socket_assign_plug:nn{tagsupport/luamplib/figure/init}{artifact} }
+    ,text     .code:n = { \socket_assign_plug:nn{tagsupport/luamplib/figure/init}{text} }
+    ,off      .code:n = { \socket_assign_plug:nn{tagsupport/luamplib/figure/init}{off} }
     ,tag      .code:n =
       {
         \str_case:nnF {#1}
           {
-            {false}    { \keys_set:nn {luamplib/tag} {off} }
-            {artifact} { \keys_set:nn {luamplib/tag} {artifact} }
+            {false}    { \keys_set:nn {luamplib/tagging} {off} }
+            {artifact} { \keys_set:nn {luamplib/tagging} {artifact} }
           }
           {
             \tl_set:Nn\l__luamplib_tag_struct_tl{#1}
-            \socket_assign_plug:nn{tagsupport/luamplib/init}{alt}
+            \socket_assign_plug:nn{tagsupport/luamplib/figure/init}{alt}
           }
       }
     ,adjust-BBox .code:n =
@@ -5623,7 +5630,7 @@ end
         \bool_set_true:N \l__luamplib_tag_bboxcorr_bool
         \seq_set_split:Nnn \l__luamplib_tag_bboxcorr_seq{~}{#1~0pt~0pt~0pt~0pt}
       }
-    ,tagging-setup .code:n = { \keys_set_known:nn {luamplib/tag} {#1} }
+    ,tagging-setup .code:n = { \keys_set_known:nn {luamplib/tagging} {#1} }
   }
 \keys_define:nn {luamplib/instance}
   {
@@ -5638,7 +5645,7 @@ end
   {
     \prependtomplibbox
     \hbox dir~TLT\bgroup
-    \tag_socket_use:n{luamplib/begin}
+    \tag_socket_use:n{luamplib/figure/begin}
     \xdef\MPllx{#1}\xdef\MPlly{#2}%
     \xdef\MPurx{#3}\xdef\MPury{#4}%
     \xdef\MPwidth{\the\dimexpr#3bp-#1bp\relax}%
@@ -5668,31 +5675,31 @@ end
        \box\mplibscratchbox}%
     \wd\mplibscratchbox\MPwidth
     \ht\mplibscratchbox\MPheight
-    \tag_socket_use:nn{luamplib/bbox}\mplibscratchbox
+    \tag_socket_use:nn{luamplib/figure/bbox}\mplibscratchbox
     \box\mplibscratchbox
-    \tag_socket_use:n{luamplib/end}
+    \tag_socket_use:n{luamplib/figure/end}
     \egroup
   }
 \RenewDocumentCommand\mplibcode{O{}}
   {
     \tl_set:Nn \l__luamplib_tag_envname_tl {mplibcode}
     \tl_gset_eq:NN \currentmpinstancename \c_empty_tl
-    \keys_set_known:neN {luamplib/tag} {#1} \l_tmpa_tl
+    \keys_set_known:neN {luamplib/tagging} {#1} \l_tmpa_tl
     \keys_set:nV {luamplib/instance} \l_tmpa_tl
     \tl_if_empty:NF \currentmpinstancename
       { \tl_set:Nn\l__luamplib_tag_alt_dflt_tl {metapost~figure~\currentmpinstancename} }
-    \tag_socket_use:n{luamplib/init}
+    \tag_socket_use:n{luamplib/figure/init}
     \mplibtmptoks{}\ltxdomplibcode
   }
 \RenewDocumentCommand\mpfig{s O{}}
   {
     \begingroup
     \tl_set:Nn \l__luamplib_tag_envname_tl {mpfig}
-    \keys_set_known:neN {luamplib/tag} {#2} \l_tmpa_tl
+    \keys_set_known:neN {luamplib/tagging} {#2} \l_tmpa_tl
     \keys_set:nV {luamplib/instance} \l_tmpa_tl
     \tl_if_empty:NF \mpfiginstancename
       { \tl_set:Nn\l__luamplib_tag_alt_dflt_tl {metapost~figure~\mpfiginstancename} }
-    \tag_socket_use:n{luamplib/init}
+    \tag_socket_use:n{luamplib/figure/init}
     \IfBooleanTF{#1}
       { \mplibprempfig * }
       { \mplibmainmpfig }
@@ -5701,20 +5708,20 @@ end
   {
     \begingroup
     \tl_set:Nn \l__luamplib_tag_envname_tl {usemplibgroup}
-    \keys_set_known:neN {luamplib/tag} {#1} \l_tmpa_tl
+    \keys_set_known:neN {luamplib/tagging} {#1} \l_tmpa_tl
     \keys_set:nV {luamplib/instance} \l_tmpa_tl
     \tl_set:Nn\l__luamplib_tag_alt_dflt_tl {metapost~figure~#2}
-    \tag_socket_use:n{luamplib/init}
+    \tag_socket_use:n{luamplib/figure/init}
     \prependtomplibbox\hbox dir~TLT\bgroup
-    \tag_socket_use:n{luamplib/begin}
+    \tag_socket_use:n{luamplib/figure/begin}
     \setbox\mplibscratchbox\hbox\bgroup
     \tag_socket_use:n{luamplib/mplibgroup/begin}
     \csname luamplib.group.#2\endcsname
     \tag_socket_use:n{luamplib/mplibgroup/end}
     \egroup
-    \tag_socket_use:nn{luamplib/bbox}\mplibscratchbox
+    \tag_socket_use:nn{luamplib/figure/bbox}\mplibscratchbox
     \unhbox\mplibscratchbox
-    \tag_socket_use:n{luamplib/end}
+    \tag_socket_use:n{luamplib/figure/end}
     \egroup
     \endgroup
   }

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -5229,6 +5229,7 @@ end
 \msg_new:nnn {luamplib}{figure-text-reuse}
 {
   tex-text~box~#1~probably~is~incorrectly~tagged.\\
+  Check~the~resulting~PDF.~
   Reusing~a~box~in~text-mode~figures~is~strongly~discouraged.
 }
 \msg_new:nnn{luamplib}{alt-text-missing}
@@ -5260,9 +5261,6 @@ end
 }
 \socket_new_plug:nnn{tagsupport/luamplib/textext/put}{default}
 {
-  \bool_if:NTF \l__luamplib_tag_usetext_bool
-  {
-    \tag_resume:n{\mplibputtextbox}
     \tag_mc_end:
     \cs_if_exist:cTF {luamplib.tagbox.#1}
     {
@@ -5272,22 +5270,20 @@ end
     {
       \msg_warning:nnn{luamplib}{figure-text-reuse}{#1}
       \tag_mc_begin:n{}
-      \int_set:Nn \l_tmpa_int {#1}
-      \tag_mc_reset_box:N \l_tmpa_int
-      #2
+      \__luamplib_tag_box_reset_put:nn{#1}{#2}
       \tag_mc_end:
     }
     \tag_mc_begin:n{artifact}
-  }
-  {
-    \int_set:Nn \l_tmpa_int {#1}
-    \tag_mc_reset_box:N \l_tmpa_int
-    #2
-  }
 }
 \socket_assign_plug:nn{tagsupport/luamplib/textext/begin}{default}
 \socket_assign_plug:nn{tagsupport/luamplib/textext/end}{default}
 \socket_assign_plug:nn{tagsupport/luamplib/textext/put}{default}
+\cs_set_nopar:Npn \__luamplib_tag_box_reset_put:nn #1 #2
+{
+  \int_set:Nn \l_tmpa_int {#1}
+  \tag_mc_reset_box:N \l_tmpa_int
+  #2
+}
 \cs_set_nopar:Npn \luamplibtagtextbegin #1
 {
   \bool_if:NTF \l__luamplib_tag_usetext_bool
@@ -5295,9 +5291,8 @@ end
     \tag_socket_use:nn{luamplib/textext/begin}{#1}
   }
   {
-    \tag_if_active:TF
-      { \bool_set_true:N \l_tmpa_bool }
-      { \bool_set_false:N \l_tmpa_bool }
+    \tag_if_active:TF { \bool_set_true:N \l_tmpa_bool }
+                      { \bool_set_false:N \l_tmpa_bool }
     \tag_suspend:n{\luamplibtagtextbegin}
   }
 }
@@ -5308,23 +5303,25 @@ end
     \tag_socket_use:n{luamplib/textext/end}
   }
   {
-    \bool_if:NT \l_tmpa_bool
-      { \tag_resume:n{\luamplibtagtextend} }
+    \bool_if:NT \l_tmpa_bool { \tag_resume:n{\luamplibtagtextend} }
   }
 }
 \cs_set_nopar:Npn \mplibputtextbox #1
 {
   \vbox to 0pt{\vss\hbox to 0pt{%
-%    \end{macrocode}
-% This socket should be always active.
-%    \begin{macrocode}
-    \socket_use:nnn{tagsupport/luamplib/textext/put}{#1}{\raise\dp#1\copy#1}
+    \bool_if:NTF \l__luamplib_tag_usetext_bool
+    {
+      \tag_resume:n{\mplibputtextbox}
+      \tag_socket_use:nnn{luamplib/textext/put}{#1}{\raise\dp#1\copy#1}
+    }
+    {
+      \__luamplib_tag_box_reset_put:nn{#1}{\raise\dp#1\copy#1}
+    }
   \hss}}
 }
 %    \end{macrocode}
-% TODO: Not sure whether asgroup will be tagged correctly.
-%       At least, this will raise a warning;
-%       but how can we tease out whether a tex-text box is for asgroup or not?
+% TODO: Not sure whether asgroup/mplibgroup will be tagged correctly. Probably not.
+%       At least, this will raise a warning.
 %    \begin{macrocode}
 \cs_set_nopar:Npn \luamplibtagasgroupinit
 {
@@ -5445,64 +5442,90 @@ end
   \tl_set:Ne \l__luamplib_BBox_ury_tl
     { \dim_to_decimal_in_bp:n { \l__luamplib_BBox_lly_tl bp + \ht#1 + \dp#1 } }
   \bool_if:NT \l__luamplib_tag_bboxcorr_bool
+  {
+    \int_set_eq:NN \l_tmpa_int \c_zero_int
+    \tl_map_inline:nn
     {
-      \int_set_eq:NN \l_tmpa_int \c_zero_int
-      \tl_map_inline:nn
-        {
-          \l__luamplib_BBox_llx_tl
-          \l__luamplib_BBox_lly_tl
-          \l__luamplib_BBox_urx_tl
-          \l__luamplib_BBox_ury_tl
-        }
-        {
-          \int_incr:N \l_tmpa_int
-          \tl_set:Ne ##1
-            {
-              \fp_eval:n
-                {
-                  ##1
-                  +
-                  \dim_to_decimal_in_bp:n { \seq_item:NV \l__luamplib_tag_bboxcorr_seq \l_tmpa_int }
-                }
-            }
-        }
+      \l__luamplib_BBox_llx_tl
+      \l__luamplib_BBox_lly_tl
+      \l__luamplib_BBox_urx_tl
+      \l__luamplib_BBox_ury_tl
     }
+    {
+      \int_incr:N \l_tmpa_int
+      \tl_set:Ne ##1
+      {
+        \fp_eval:n
+        {
+          ##1
+          +
+          \dim_to_decimal_in_bp:n { \seq_item:NV \l__luamplib_tag_bboxcorr_seq \l_tmpa_int }
+        }
+      }
+    }
+  }
   \tag_struct_gput:ene {\tag_get:n{struct_num}} {attribute}
-    {
-      /O /Layout /BBox [
-        \l__luamplib_BBox_llx_tl\c_space_tl
-        \l__luamplib_BBox_lly_tl\c_space_tl
-        \l__luamplib_BBox_urx_tl\c_space_tl
-        \l__luamplib_BBox_ury_tl
-      ]
-    }
+  {
+    /O /Layout /BBox [
+      \l__luamplib_BBox_llx_tl\c_space_tl
+      \l__luamplib_BBox_lly_tl\c_space_tl
+      \l__luamplib_BBox_urx_tl\c_space_tl
+      \l__luamplib_BBox_ury_tl
+    ]
+  }
   \bool_if:NT \l__tag_graphic_debug_bool
+  {
+    \iow_log:e
     {
-      \iow_log:e
+      luamplib/tagging~debug:~BBox~of~structure~\tag_get:n{struct_num}~is~
+      \l__luamplib_BBox_llx_tl\c_space_tl
+      \l__luamplib_BBox_lly_tl\c_space_tl
+      \l__luamplib_BBox_urx_tl\c_space_tl
+      \l__luamplib_BBox_ury_tl
+    }
+    \sys_if_output_pdf:TF
+    {
+      \tl_set:Ne \l__luamplib_tag_bbox_draw_tl
+      {
+        \pdfextension save\relax
+        \color_group_begin:
+        \opacity_select:n{0.5} \color_select:n{red}
+        \pdfextension literal~text
         {
-          luamplib/tagging~debug:~BBox~of~structure~\tag_get:n{struct_num}~is~
           \l__luamplib_BBox_llx_tl\c_space_tl
           \l__luamplib_BBox_lly_tl\c_space_tl
-          \l__luamplib_BBox_urx_tl\c_space_tl
-          \l__luamplib_BBox_ury_tl
+          \fp_eval:n { \l__luamplib_BBox_urx_tl - \l__luamplib_BBox_llx_tl }~
+          \fp_eval:n { \l__luamplib_BBox_ury_tl - \l__luamplib_BBox_lly_tl }~
+          re~f
         }
-      \tl_set:Ne \l__luamplib_tag_bbox_draw_tl
-        {
-          \pdfextension save\relax
-          \color_group_begin:
-          \opacity_select:n{0.5} \color_select:n{red}
-          \pdfextension literal~text
-            {
-              \l__luamplib_BBox_llx_tl\c_space_tl
-              \l__luamplib_BBox_lly_tl\c_space_tl
-              \fp_eval:n { \l__luamplib_BBox_urx_tl - \l__luamplib_BBox_llx_tl }~
-              \fp_eval:n { \l__luamplib_BBox_ury_tl - \l__luamplib_BBox_lly_tl }~
-              re~f
-            }
-          \color_group_end:
-          \pdfextension restore\relax
-        }
+        \color_group_end:
+        \pdfextension restore\relax
+      }
     }
+    {
+      \tl_set:Ne \l__luamplib_tag_bbox_draw_tl
+      {
+        \special{pdf:bcontent}
+        \color_group_begin:
+        \opacity_select:n{0.5} \color_select:n{red}
+        \special{pdf:code~
+          1~0~0~1~
+          -\dim_to_decimal_in_bp:n { \property_ref:een{\l_tmpa_tl}{xpos}{0}sp + \wd#1 }~
+          -\dim_to_decimal_in_bp:n { \property_ref:een{\l_tmpa_tl}{ypos}{0}sp }~
+          cm
+        }
+        \special{pdf:code~
+          \l__luamplib_BBox_llx_tl\c_space_tl
+          \l__luamplib_BBox_lly_tl\c_space_tl
+          \fp_eval:n { \l__luamplib_BBox_urx_tl - \l__luamplib_BBox_llx_tl }~
+          \fp_eval:n { \l__luamplib_BBox_ury_tl - \l__luamplib_BBox_lly_tl }~
+          re~f
+        }
+        \color_group_end:
+        \special{pdf:econtent}
+      }
+    }
+  }
 }
 %    \end{macrocode}
 % horizontal mode upon |text| and |actualtext|
@@ -5569,128 +5592,127 @@ end
 % Key-value options
 %    \begin{macrocode}
 \keys_define:nn{luamplib/tagging}
+{
+  ,alt .code:n =
   {
-    ,alt .code:n =
-      {
-        \tl_set:Ne\l__luamplib_tag_alt_tl{\text_purify:n{#1}}
-        \socket_assign_plug:nn{tagsupport/luamplib/figure/init}{alt}
-      }
-    ,actualtext .code:n =
-      {
-        \tl_set:Ne\l__luamplib_tag_actual_tl{\text_purify:n{#1}}
-        \socket_assign_plug:nn{tagsupport/luamplib/figure/init}{actualtext}
-      }
-    ,artifact .code:n = { \socket_assign_plug:nn{tagsupport/luamplib/figure/init}{artifact} }
-    ,text     .code:n = { \socket_assign_plug:nn{tagsupport/luamplib/figure/init}{text} }
-    ,off      .code:n = { \socket_assign_plug:nn{tagsupport/luamplib/figure/init}{off} }
-    ,tag      .code:n =
-      {
-        \str_case:nnF {#1}
-          {
-            {false}    { \keys_set:nn {luamplib/tagging} {off} }
-            {artifact} { \keys_set:nn {luamplib/tagging} {artifact} }
-          }
-          {
-            \tl_set:Nn\l__luamplib_tag_struct_tl{#1}
-            \socket_assign_plug:nn{tagsupport/luamplib/figure/init}{alt}
-          }
-      }
-    ,adjust-BBox .code:n =
-      {
-        \bool_set_true:N \l__luamplib_tag_bboxcorr_bool
-        \seq_set_split:Nnn \l__luamplib_tag_bboxcorr_seq{~}{#1~0pt~0pt~0pt~0pt}
-      }
-    ,tagging-setup .code:n = { \keys_set_known:nn {luamplib/tagging} {#1} }
+    \tl_set:Ne\l__luamplib_tag_alt_tl{\text_purify:n{#1}}
+    \socket_assign_plug:nn{tagsupport/luamplib/figure/init}{alt}
   }
+  ,actualtext .code:n =
+  {
+    \tl_set:Ne\l__luamplib_tag_actual_tl{\text_purify:n{#1}}
+    \socket_assign_plug:nn{tagsupport/luamplib/figure/init}{actualtext}
+  }
+  ,artifact .code:n = { \socket_assign_plug:nn{tagsupport/luamplib/figure/init}{artifact} }
+  ,text     .code:n = { \socket_assign_plug:nn{tagsupport/luamplib/figure/init}{text} }
+  ,off      .code:n = { \socket_assign_plug:nn{tagsupport/luamplib/figure/init}{off} }
+  ,tag      .code:n =
+  {
+    \str_case:nnF {#1}
+    {
+      {false}    { \keys_set:nn {luamplib/tagging} {off} }
+      {artifact} { \keys_set:nn {luamplib/tagging} {artifact} }
+    }
+    {
+      \tl_set:Nn\l__luamplib_tag_struct_tl{#1}
+      \socket_assign_plug:nn{tagsupport/luamplib/figure/init}{alt}
+    }
+  }
+  ,adjust-BBox .code:n =
+  {
+    \bool_set_true:N \l__luamplib_tag_bboxcorr_bool
+    \seq_set_split:Nnn \l__luamplib_tag_bboxcorr_seq{~}{#1~0pt~0pt~0pt~0pt}
+  }
+  ,tagging-setup .code:n = { \keys_set_known:nn {luamplib/tagging} {#1} }
+}
 \keys_define:nn {luamplib/instance}
-  {
-    ,instance     .code:n = { \tl_gset:Nn \currentmpinstancename {#1} }
-    ,instancename .meta:n = { instance = {#1} }
-    ,unknown      .code:n = { \tl_gset:NV \currentmpinstancename \l_keys_key_str }
-  }
+{
+  ,instance     .code:n = { \tl_gset:Nn \currentmpinstancename {#1} }
+  ,instancename .meta:n = { instance = {#1} }
+  ,unknown      .code:n = { \tl_gset:NV \currentmpinstancename \l_keys_key_str }
+}
 %    \end{macrocode}
 % Redefine our macros
 %    \begin{macrocode}
 \cs_set_nopar:Npn \mplibstarttoPDF #1 #2 #3 #4
-  {
-    \prependtomplibbox
-    \hbox dir~TLT\bgroup
-    \tag_socket_use:nn{luamplib/figure/begin}\l__luamplib_tag_alt_dflt_tl
-    \xdef\MPllx{#1}\xdef\MPlly{#2}%
-    \xdef\MPurx{#3}\xdef\MPury{#4}%
-    \xdef\MPwidth{\the\dimexpr#3bp-#1bp\relax}%
-    \xdef\MPheight{\the\dimexpr#4bp-#2bp\relax}%
-    \parskip0pt
-    \leftskip0pt
-    \parindent0pt
-    \everypar{}%
-    \setbox\mplibscratchbox\vbox\bgroup
-    \tag_suspend:n{\mplibstarttoPDF}
-    \noindent
-  }
+{
+  \prependtomplibbox
+  \hbox dir~TLT\bgroup
+  \tag_socket_use:nn{luamplib/figure/begin}\l__luamplib_tag_alt_dflt_tl
+  \xdef\MPllx{#1}\xdef\MPlly{#2}%
+  \xdef\MPurx{#3}\xdef\MPury{#4}%
+  \xdef\MPwidth{\the\dimexpr#3bp-#1bp\relax}%
+  \xdef\MPheight{\the\dimexpr#4bp-#2bp\relax}%
+  \parskip0pt
+  \leftskip0pt
+  \parindent0pt
+  \everypar{}%
+  \setbox\mplibscratchbox\vbox\bgroup
+  \tag_suspend:n{\mplibstarttoPDF}
+  \noindent
+}
 \cs_set_nopar:Npn \mplibstoptoPDF
-  {
-    \par
-    \egroup
-    \setbox\mplibscratchbox\hbox
-      {\hskip-\MPllx bp
-       \raise-\MPlly bp
-       \box\mplibscratchbox}%
-    \setbox\mplibscratchbox\vbox to \MPheight
-      {\vfill
-       \hsize\MPwidth
-       \wd\mplibscratchbox0pt
-       \ht\mplibscratchbox0pt
-       \dp\mplibscratchbox0pt
-       \box\mplibscratchbox}%
-    \wd\mplibscratchbox\MPwidth
-    \ht\mplibscratchbox\MPheight
-    \tag_socket_use:nn{luamplib/figure/bbox}\mplibscratchbox
-    \box\mplibscratchbox
-    \tag_socket_use:n{luamplib/figure/end}
-    \egroup
-  }
+{
+  \par
+  \egroup
+  \setbox\mplibscratchbox\hbox
+    {\hskip-\MPllx bp
+     \raise-\MPlly bp
+     \box\mplibscratchbox}%
+  \setbox\mplibscratchbox\vbox to \MPheight
+    {\vfill
+     \hsize\MPwidth
+     \wd\mplibscratchbox0pt
+     \ht\mplibscratchbox0pt
+     \dp\mplibscratchbox0pt
+     \box\mplibscratchbox}%
+  \wd\mplibscratchbox\MPwidth
+  \ht\mplibscratchbox\MPheight
+  \tag_socket_use:nn{luamplib/figure/bbox}\mplibscratchbox
+  \box\mplibscratchbox
+  \tag_socket_use:n{luamplib/figure/end}
+  \egroup
+}
 \RenewDocumentCommand\mplibcode{O{}}
-  {
-    \tl_set:Nn \l__luamplib_tag_envname_tl {mplibcode}
-    \tl_gset_eq:NN \currentmpinstancename \c_empty_tl
-    \keys_set_known:neN {luamplib/tagging} {#1} \l_tmpa_tl
-    \keys_set:nV {luamplib/instance} \l_tmpa_tl
-    \tl_set_eq:NN \l__luamplib_tag_alt_dflt_tl \currentmpinstancename
-    \tag_socket_use:n{luamplib/figure/init}
-    \mplibtmptoks{}\ltxdomplibcode
-  }
+{
+  \tl_set:Nn \l__luamplib_tag_envname_tl {mplibcode}
+  \tl_gset_eq:NN \currentmpinstancename \c_empty_tl
+  \keys_set_known:neN {luamplib/tagging} {#1} \l_tmpa_tl
+  \keys_set:nV {luamplib/instance} \l_tmpa_tl
+  \tl_set_eq:NN \l__luamplib_tag_alt_dflt_tl \currentmpinstancename
+  \tag_socket_use:n{luamplib/figure/init}
+  \mplibtmptoks{}\ltxdomplibcode
+}
 \RenewDocumentCommand\mpfig{s O{}}
-  {
-    \begingroup
-    \tl_set:Nn \l__luamplib_tag_envname_tl {mpfig}
-    \keys_set_known:ne {luamplib/tagging} {#2}
-    \tl_set_eq:NN \l__luamplib_tag_alt_dflt_tl \mpfiginstancename
-    \tag_socket_use:n{luamplib/figure/init}
-    \IfBooleanTF{#1}
-      { \mplibprempfig * }
-      { \mplibmainmpfig }
-  }
+{
+  \begingroup
+  \tl_set:Nn \l__luamplib_tag_envname_tl {mpfig}
+  \keys_set_known:ne {luamplib/tagging} {#2}
+  \tl_set_eq:NN \l__luamplib_tag_alt_dflt_tl \mpfiginstancename
+  \tag_socket_use:n{luamplib/figure/init}
+  \IfBooleanTF{#1} { \mplibprempfig * }
+                   { \mplibmainmpfig }
+}
 \RenewDocumentCommand\usemplibgroup{O{} m}
-  {
-    \begingroup
-    \tl_set:Nn \l__luamplib_tag_envname_tl {usemplibgroup}
-    \keys_set_known:ne {luamplib/tagging} {#1}
-    \tl_set:Nn \l__luamplib_tag_alt_dflt_tl {#2}
-    \tag_socket_use:n{luamplib/figure/init}
-    \prependtomplibbox\hbox dir~TLT\bgroup
-    \tag_socket_use:nn{luamplib/figure/begin}\l__luamplib_tag_alt_dflt_tl
-    \setbox\mplibscratchbox\hbox\bgroup
-    \tag_socket_use:n{luamplib/mplibgroup/begin}
-    \csname luamplib.group.#2\endcsname
-    \tag_socket_use:n{luamplib/mplibgroup/end}
-    \egroup
-    \tag_socket_use:nn{luamplib/figure/bbox}\mplibscratchbox
-    \unhbox\mplibscratchbox
-    \tag_socket_use:n{luamplib/figure/end}
-    \egroup
-    \endgroup
-  }
+{
+  \begingroup
+  \tl_set:Nn \l__luamplib_tag_envname_tl {usemplibgroup}
+  \keys_set_known:ne {luamplib/tagging} {#1}
+  \tl_set:Nn \l__luamplib_tag_alt_dflt_tl {#2}
+  \tag_socket_use:n{luamplib/figure/init}
+  \prependtomplibbox\hbox dir~TLT\bgroup
+  \tag_socket_use:nn{luamplib/figure/begin}\l__luamplib_tag_alt_dflt_tl
+  \setbox\mplibscratchbox\hbox\bgroup
+  \tag_socket_use:n{luamplib/mplibgroup/begin}
+  \csname luamplib.group.#2\endcsname
+  \tag_socket_use:n{luamplib/mplibgroup/end}
+  \egroup
+  \tag_socket_use:nn{luamplib/figure/bbox}\mplibscratchbox
+  \unhbox\mplibscratchbox
+  \tag_socket_use:n{luamplib/figure/end}
+  \egroup
+  \endgroup
+}
 %    \end{macrocode}
 % Allow setting alt/actual text within \metapost code
 %    \begin{macrocode}

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -3009,7 +3009,7 @@ def withgroupname expr s =
   withprescript "mplibgroupname=" & s
 enddef;
 def usemplibgroup primary s =
-  draw maketext("\csname luamplib.group." & s & "\endcsname")
+  draw maketext("\luamplibtagasgroupput{"& s &"}{\csname luamplib.group."& s &"\endcsname}")
     shifted runscript("return luamplib.trgroupshifts['" & s & "']")
 enddef;
 path    mplib_shade_path ;
@@ -5233,8 +5233,8 @@ end
 }
 \msg_new:nnn {luamplib}{mplibgroup-text-mode}
 {
-  mplibgroup/asgroup~'#1'~probably~is~incorrectly~tagged.~
-  Using~mplibgroup/asgroup~with~text~mode~is~not~recommended.~
+  mplibgroup~'#1'~probably~is~incorrectly~tagged.~
+  Using~mplibgroup~with~text~mode~is~not~recommended.~
   Check~the~resulting~PDF.
 }
 \msg_new:nnn{luamplib}{alt-text-missing}
@@ -5340,7 +5340,7 @@ end
     \cs_gset_nopar:cpn {luamplib.mplibgroup.text.#1} {#1}
   }
   \tag_mc_end:
-  \tag_mc_begin:n{}
+  \tag_mc_begin:n{tag=text}
   #2
   \tag_mc_end:
   \tag_mc_begin:n{artifact}

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -5224,7 +5224,6 @@ end
 \bool_new:N \l__luamplib_tag_bboxcorr_bool
 \seq_new:N  \l__luamplib_tag_bboxcorr_seq
 \tl_new:N \l__luamplib_tag_bbox_draw_tl
-\tl_new:N \l__luamplib_BBox_label_tl
 \tl_new:N \l__luamplib_BBox_llx_tl
 \tl_new:N \l__luamplib_BBox_lly_tl
 \tl_new:N \l__luamplib_BBox_urx_tl
@@ -5439,28 +5438,24 @@ end
 \socket_new:nn{tagsupport/luamplib/figure/bbox}{1}
 \socket_new_plug:nnn{tagsupport/luamplib/figure/bbox}{alt}
 {
-    \tl_set:Ne \l__luamplib_BBox_label_tl {luamplib.BBox.\tag_get:n{struct_num}}
+    \tl_set:Ne \l_tmpa_tl {luamplib.BBox.\tag_get:n{struct_num}}
     \tex_savepos:D
-    \property_record:ee{\l__luamplib_BBox_label_tl}{xpos,ypos}
+    \property_record:ee{\l_tmpa_tl}{xpos,ypos}
     \tl_set:Ne \l__luamplib_BBox_llx_tl
       {
-        \dim_to_decimal_in_bp:n
-        { \property_ref:een {\l__luamplib_BBox_label_tl}{xpos}{0}sp }
+        \dim_to_decimal_in_bp:n { \property_ref:een {\l_tmpa_tl}{xpos}{0}sp }
       }
     \tl_set:Ne \l__luamplib_BBox_lly_tl
       {
-        \dim_to_decimal_in_bp:n
-        { \property_ref:een {\l__luamplib_BBox_label_tl}{ypos}{0}sp - \dp#1 }
+        \dim_to_decimal_in_bp:n { \property_ref:een {\l_tmpa_tl}{ypos}{0}sp - \dp#1 }
       }
     \tl_set:Ne \l__luamplib_BBox_urx_tl
       {
-        \dim_to_decimal_in_bp:n
-        { \l__luamplib_BBox_llx_tl bp + \wd#1 }
+        \dim_to_decimal_in_bp:n { \l__luamplib_BBox_llx_tl bp + \wd#1 }
       }
     \tl_set:Ne \l__luamplib_BBox_ury_tl
       {
-        \dim_to_decimal_in_bp:n
-        { \l__luamplib_BBox_lly_tl bp + \ht#1 + \dp#1 }
+        \dim_to_decimal_in_bp:n { \l__luamplib_BBox_lly_tl bp + \ht#1 + \dp#1 }
       }
     \bool_if:NT \l__luamplib_tag_bboxcorr_bool
       {

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -5199,7 +5199,7 @@ end
       ,tagging-setup .code:n = { }
       ,instance     .code:n = { \tl_gset:Nn \currentmpinstancename {#1} }
       ,instancename .meta:n = { instance = {#1} }
-      ,unknown      .code:n = { \tl_gset:Ne \currentmpinstancename {\l_keys_key_str} }
+      ,unknown      .code:n = { \tl_gset:NV \currentmpinstancename \l_keys_key_str }
     }
   \RenewDocumentCommand\mplibcode{O{}}
     {
@@ -5213,10 +5213,8 @@ end
   \endinput\fi
 \ExplSyntaxOn
 \tl_new:N \l__luamplib_tag_envname_tl
-\tl_set:Nn\l__luamplib_tag_envname_tl {mplibcode}
 \tl_new:N \l__luamplib_tag_alt_tl
 \tl_new:N \l__luamplib_tag_alt_dflt_tl
-\tl_set:Nn\l__luamplib_tag_alt_dflt_tl {metapost~figure}
 \tl_new:N \l__luamplib_tag_actual_tl
 \tl_new:N \l__luamplib_tag_struct_tl
 \tl_set:Nn\l__luamplib_tag_struct_tl {Figure}
@@ -5381,16 +5379,18 @@ end
 %    \end{macrocode}
 % Sockets for main process
 %    \begin{macrocode}
-\socket_new:nn{tagsupport/luamplib/figure/begin}{0}
+\socket_new:nn{tagsupport/luamplib/figure/begin}{1}
 \socket_new:nn{tagsupport/luamplib/figure/end}{0}
 \socket_new_plug:nnn{tagsupport/luamplib/figure/begin}{alt}
 {
     \tag_mc_end_push:
     \tl_if_empty:NT\l__luamplib_tag_alt_tl
     {
-      \msg_warning:nnee{luamplib}{alt-text-missing}
-                       {\l__luamplib_tag_envname_tl}{\l__luamplib_tag_alt_dflt_tl}
-      \tl_set:Ne\l__luamplib_tag_alt_tl {\l__luamplib_tag_alt_dflt_tl}
+      \tl_if_empty:eTF{#1}
+        { \tl_set:Nn \l__luamplib_tag_alt_tl {metapost~figure} }
+        { \tl_set:Ne \l__luamplib_tag_alt_tl {metapost~figure~\text_purify:n{#1}} }
+      \msg_warning:nnVV{luamplib}{alt-text-missing}
+                       \l__luamplib_tag_envname_tl \l__luamplib_tag_alt_tl
     }
     \tag_struct_begin:n
     {
@@ -5438,100 +5438,76 @@ end
 \socket_new:nn{tagsupport/luamplib/figure/bbox}{1}
 \socket_new_plug:nnn{tagsupport/luamplib/figure/bbox}{alt}
 {
-    \tl_set:Ne \l_tmpa_tl {luamplib.BBox.\tag_get:n{struct_num}}
-    \tex_savepos:D
-    \property_record:ee{\l_tmpa_tl}{xpos,ypos}
-    \tl_set:Ne \l__luamplib_BBox_llx_tl
-      {
-        \dim_to_decimal_in_bp:n { \property_ref:een {\l_tmpa_tl}{xpos}{0}sp }
-      }
-    \tl_set:Ne \l__luamplib_BBox_lly_tl
-      {
-        \dim_to_decimal_in_bp:n { \property_ref:een {\l_tmpa_tl}{ypos}{0}sp - \dp#1 }
-      }
-    \tl_set:Ne \l__luamplib_BBox_urx_tl
-      {
-        \dim_to_decimal_in_bp:n { \l__luamplib_BBox_llx_tl bp + \wd#1 }
-      }
-    \tl_set:Ne \l__luamplib_BBox_ury_tl
-      {
-        \dim_to_decimal_in_bp:n { \l__luamplib_BBox_lly_tl bp + \ht#1 + \dp#1 }
-      }
-    \bool_if:NT \l__luamplib_tag_bboxcorr_bool
-      {
-        \tl_set:Ne \l__luamplib_BBox_llx_tl
-          {
-            \fp_eval:n
+  \tl_set:Ne \l_tmpa_tl {luamplib.BBox.\tag_get:n{struct_num}}
+  \tex_savepos:D
+  \property_record:ee{\l_tmpa_tl}{xpos,ypos}
+  \tl_set:Ne \l__luamplib_BBox_llx_tl
+    { \dim_to_decimal_in_bp:n { \property_ref:een {\l_tmpa_tl}{xpos}{0}sp } }
+  \tl_set:Ne \l__luamplib_BBox_lly_tl
+    { \dim_to_decimal_in_bp:n { \property_ref:een {\l_tmpa_tl}{ypos}{0}sp - \dp#1 } }
+  \tl_set:Ne \l__luamplib_BBox_urx_tl
+    { \dim_to_decimal_in_bp:n { \l__luamplib_BBox_llx_tl bp + \wd#1 } }
+  \tl_set:Ne \l__luamplib_BBox_ury_tl
+    { \dim_to_decimal_in_bp:n { \l__luamplib_BBox_lly_tl bp + \ht#1 + \dp#1 } }
+  \bool_if:NT \l__luamplib_tag_bboxcorr_bool
+    {
+      \int_set_eq:NN \l_tmpa_int \c_zero_int
+      \tl_map_inline:nn
+        {
+          \l__luamplib_BBox_llx_tl
+          \l__luamplib_BBox_lly_tl
+          \l__luamplib_BBox_urx_tl
+          \l__luamplib_BBox_ury_tl
+        }
+        {
+          \int_incr:N \l_tmpa_int
+          \tl_set:Ne ##1
             {
-              \l__luamplib_BBox_llx_tl
-              +
-              \dim_to_decimal_in_bp:n {\seq_item:Nn \l__luamplib_tag_bboxcorr_seq {1} }
+              \fp_eval:n
+                {
+                  ##1
+                  +
+                  \dim_to_decimal_in_bp:n { \seq_item:NV \l__luamplib_tag_bboxcorr_seq \l_tmpa_int }
+                }
             }
-          }
-        \tl_set:Ne \l__luamplib_BBox_lly_tl
-          {
-            \fp_eval:n
-            {
-              \l__luamplib_BBox_lly_tl
-              +
-              \dim_to_decimal_in_bp:n {\seq_item:Nn \l__luamplib_tag_bboxcorr_seq {2} }
-            }
-          }
-        \tl_set:Ne \l__luamplib_BBox_urx_tl
-          {
-            \fp_eval:n
-            {
-              \l__luamplib_BBox_urx_tl
-              +
-              \dim_to_decimal_in_bp:n {\seq_item:Nn \l__luamplib_tag_bboxcorr_seq {3} }
-            }
-          }
-        \tl_set:Ne \l__luamplib_BBox_ury_tl
-          {
-            \fp_eval:n
-            {
-              \l__luamplib_BBox_ury_tl
-              +
-              \dim_to_decimal_in_bp:n {\seq_item:Nn \l__luamplib_tag_bboxcorr_seq {4} }
-            }
-          }
-      }
-    \tag_struct_gput:ene {\tag_get:n{struct_num}} {attribute}
-      {
-        /O /Layout /BBox [
+        }
+    }
+  \tag_struct_gput:ene {\tag_get:n{struct_num}} {attribute}
+    {
+      /O /Layout /BBox [
+        \l__luamplib_BBox_llx_tl\c_space_tl
+        \l__luamplib_BBox_lly_tl\c_space_tl
+        \l__luamplib_BBox_urx_tl\c_space_tl
+        \l__luamplib_BBox_ury_tl
+      ]
+    }
+  \bool_if:NT \l__tag_graphic_debug_bool
+    {
+      \iow_log:e
+        {
+          luamplib/tagging~debug:~BBox~of~structure~\tag_get:n{struct_num}~is~
           \l__luamplib_BBox_llx_tl\c_space_tl
           \l__luamplib_BBox_lly_tl\c_space_tl
           \l__luamplib_BBox_urx_tl\c_space_tl
           \l__luamplib_BBox_ury_tl
-        ]
-      }
-    \bool_if:NT \l__tag_graphic_debug_bool
-      {
-        \iow_log:e
-          {
-            luamplib/tagging~debug:~BBox~of~structure~\tag_get:n{struct_num}~is~
-            \l__luamplib_BBox_llx_tl\c_space_tl
-            \l__luamplib_BBox_lly_tl\c_space_tl
-            \l__luamplib_BBox_urx_tl\c_space_tl
-            \l__luamplib_BBox_ury_tl
-          }
-        \tl_set:Ne \l__luamplib_tag_bbox_draw_tl
+        }
+      \tl_set:Ne \l__luamplib_tag_bbox_draw_tl
         {
           \pdfextension save\relax
           \color_group_begin:
           \opacity_select:n{0.5} \color_select:n{red}
           \pdfextension literal~text
-          {
-            \l__luamplib_BBox_llx_tl\c_space_tl
-            \l__luamplib_BBox_lly_tl\c_space_tl
-            \fp_eval:n { \l__luamplib_BBox_urx_tl - \l__luamplib_BBox_llx_tl }~
-            \fp_eval:n { \l__luamplib_BBox_ury_tl - \l__luamplib_BBox_lly_tl }~
-            re~f
-          }
+            {
+              \l__luamplib_BBox_llx_tl\c_space_tl
+              \l__luamplib_BBox_lly_tl\c_space_tl
+              \fp_eval:n { \l__luamplib_BBox_urx_tl - \l__luamplib_BBox_llx_tl }~
+              \fp_eval:n { \l__luamplib_BBox_ury_tl - \l__luamplib_BBox_lly_tl }~
+              re~f
+            }
           \color_group_end:
           \pdfextension restore\relax
         }
-      }
+    }
 }
 %    \end{macrocode}
 % horizontal mode upon |text| and |actualtext|
@@ -5631,7 +5607,7 @@ end
   {
     ,instance     .code:n = { \tl_gset:Nn \currentmpinstancename {#1} }
     ,instancename .meta:n = { instance = {#1} }
-    ,unknown      .code:n = { \tl_gset:Ne \currentmpinstancename {\l_keys_key_str} }
+    ,unknown      .code:n = { \tl_gset:NV \currentmpinstancename \l_keys_key_str }
   }
 %    \end{macrocode}
 % Redefine our macros
@@ -5640,7 +5616,7 @@ end
   {
     \prependtomplibbox
     \hbox dir~TLT\bgroup
-    \tag_socket_use:n{luamplib/figure/begin}
+    \tag_socket_use:nn{luamplib/figure/begin}\l__luamplib_tag_alt_dflt_tl
     \xdef\MPllx{#1}\xdef\MPlly{#2}%
     \xdef\MPurx{#3}\xdef\MPury{#4}%
     \xdef\MPwidth{\the\dimexpr#3bp-#1bp\relax}%
@@ -5681,8 +5657,7 @@ end
     \tl_gset_eq:NN \currentmpinstancename \c_empty_tl
     \keys_set_known:neN {luamplib/tagging} {#1} \l_tmpa_tl
     \keys_set:nV {luamplib/instance} \l_tmpa_tl
-    \tl_if_empty:NF \currentmpinstancename
-      { \tl_set:Nn\l__luamplib_tag_alt_dflt_tl {metapost~figure~\currentmpinstancename} }
+    \tl_set_eq:NN \l__luamplib_tag_alt_dflt_tl \currentmpinstancename
     \tag_socket_use:n{luamplib/figure/init}
     \mplibtmptoks{}\ltxdomplibcode
   }
@@ -5690,10 +5665,8 @@ end
   {
     \begingroup
     \tl_set:Nn \l__luamplib_tag_envname_tl {mpfig}
-    \keys_set_known:neN {luamplib/tagging} {#2} \l_tmpa_tl
-    \keys_set:nV {luamplib/instance} \l_tmpa_tl
-    \tl_if_empty:NF \mpfiginstancename
-      { \tl_set:Nn\l__luamplib_tag_alt_dflt_tl {metapost~figure~\mpfiginstancename} }
+    \keys_set_known:ne {luamplib/tagging} {#2}
+    \tl_set_eq:NN \l__luamplib_tag_alt_dflt_tl \mpfiginstancename
     \tag_socket_use:n{luamplib/figure/init}
     \IfBooleanTF{#1}
       { \mplibprempfig * }
@@ -5703,12 +5676,11 @@ end
   {
     \begingroup
     \tl_set:Nn \l__luamplib_tag_envname_tl {usemplibgroup}
-    \keys_set_known:neN {luamplib/tagging} {#1} \l_tmpa_tl
-    \keys_set:nV {luamplib/instance} \l_tmpa_tl
-    \tl_set:Nn\l__luamplib_tag_alt_dflt_tl {metapost~figure~#2}
+    \keys_set_known:ne {luamplib/tagging} {#1}
+    \tl_set:Nn \l__luamplib_tag_alt_dflt_tl {#2}
     \tag_socket_use:n{luamplib/figure/init}
     \prependtomplibbox\hbox dir~TLT\bgroup
-    \tag_socket_use:n{luamplib/figure/begin}
+    \tag_socket_use:nn{luamplib/figure/begin}\l__luamplib_tag_alt_dflt_tl
     \setbox\mplibscratchbox\hbox\bgroup
     \tag_socket_use:n{luamplib/mplibgroup/begin}
     \csname luamplib.group.#2\endcsname

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -588,11 +588,9 @@ See source file '\inFileName' for licencing and contact information.
 %   This key is intended for figures whose meaning is the sequence of texts in the
 %   tex-text boxes in the order they are drawn in the figure.
 %   Inside |text|-mode figures, reusing tex-text boxes is strongly discouraged.
-% \item[\texttt{off}] Given this key, \pkg{luamplib} does nothing about tagging.
+% \item[\texttt{off}] Given this key, nothing will be tagged by \pkg{luamplib}.
 % \item[\texttt{tag=}\meta{name}] You can choose a tag name, default value being |Figure|.\relax
-%   \footnote{When the value, however, is |false|, tagging is deactivated,
-%     and the result is not much different from the |off| key.
-%     But the option |tag=false| also shares the limitation mentioned in the previous footnote.}
+%   \footnote{The option |tag=false|, however, is a synonym of the |off| key.}
 %   For instance, you can set `|tag=Formula,| |alt=|\meta{text}' to get
 %   a |Formula| element with its alternate text.\footnote{Beware that this bypasses
 %     \LaTeX's regular math formula tagging, for which the |text| key is needed.}
@@ -5589,11 +5587,6 @@ end
   \socket_assign_plug:nn{tagsupport/luamplib/end}{noop}
   \socket_assign_plug:nn{tagsupport/luamplib/bbox}{noop}
 }
-\socket_new_plug:nnn{tagsupport/luamplib/init}{false}
-{
-  \prependtomplibbox \mplibnoforcehmode
-  \tag_suspend:n{luamplib/tag/false}
-}
 \socket_assign_plug:nn{tagsupport/luamplib/init}{alt}
 %    \end{macrocode}
 % Key-value options
@@ -5617,7 +5610,7 @@ end
       {
         \str_case:nnF {#1}
           {
-            {false}    { \socket_assign_plug:nn{tagsupport/luamplib/init}{false} }
+            {false}    { \keys_set:nn {luamplib/tag} {off} }
             {artifact} { \keys_set:nn {luamplib/tag} {artifact} }
           }
           {

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -513,7 +513,7 @@ See source file '\inFileName' for licencing and contact information.
 % \subsubsection{About cache files}
 %   To support |btex ... etex| in external |.mp| files, \pkg{luamplib}
 %   inspects the content of each and every |.mp| file and makes caches
-%   if nececcsary, before returning their paths to \LuaTeX's \mplib library.
+%   if nececcsary before returning their paths to the \mplib library.
 %   This could waste the compilation time, as most |.mp| files
 %   do not contain |btex ... etex| commands.  So \pkg{luamplib} provides
 %   macros as follows, so that users can give instructions about files
@@ -588,6 +588,19 @@ See source file '\inFileName' for licencing and contact information.
 %   This key is intended for figures the meaning of which is the sequence of texts in the
 %   tex-text boxes in the order they are drawn in the figure.
 %   Inside |text|-mode figures, reusing tex-text boxes is strongly discouraged.
+%
+%   Note that the text in a tex-text box which starts with |[taggingoff]| will not be tagged
+%   at all, and
+%   of course |[taggingoff]| and its trailing spaces will be gobbled by \pkg{luamplib}.
+%   For example, the first and the third boxes in the following figure will not be tagged,
+%   and still remain in the |Artifact| MC-chunks.
+%\begin{verbatim}
+%   \mpfig[text]
+%   draw btex [taggingoff] $\sqrt 2$ etex ;
+%   draw textext "$\sqrt 2$" shifted 10down ;
+%   draw TEX "[taggingoff] $\sqrt 2$" shifted 20down ;
+%   \endmpfig
+%\end{verbatim}
 % \item[\texttt{off}] Given this key, nothing will be tagged by \pkg{luamplib}.
 % \item[\texttt{tag=}\meta{name}] You can choose a tag name, default value being |Figure|.\relax
 %   \footnote{The option |tag=false|, however, is a synonym of the |off| key.}
@@ -1736,8 +1749,14 @@ local function process_tex_text (str, maketext)
       run_tex_code(format([[\expandafter\newbox\csname luamplib.box.%s\endcsname]], boxid))
       tex_box_id = tex.getcount'allocationnumber'
     end
-    run_tex_code(format("\\luamplibtagtextboxset{%i}{%s\\setbox%i\\hbox{%s}}",
-                        tex_box_id, global, tex_box_id, str))
+    if str:find"^%[taggingoff%]" then
+      str = str:gsub("^%[taggingoff%]%s*","")
+      run_tex_code(format("\\luamplibnotagtextboxset{%i}{%s\\setbox%i\\hbox{%s}}",
+                          tex_box_id, global, tex_box_id, str))
+    else
+      run_tex_code(format("\\luamplibtagtextboxset{%i}{%s\\setbox%i\\hbox{%s}}",
+                          tex_box_id, global, tex_box_id, str))
+    end
     local box = texgetbox(tex_box_id)
     local wd  = box.width  / factor
     local ht  = box.height / factor
@@ -5181,6 +5200,7 @@ end
 %    Code for \pkg{tagpdf}
 %    \begin{macrocode}
 \def\luamplibtagtextboxset#1#2{#2}
+\let\luamplibnotagtextboxset\luamplibtagtextboxset
 \let\luamplibtagasgroupset\relax
 \let\luamplibtagasgroupput\luamplibtagtextboxset
 \ifcsname SuspendTagging\endcsname\else\endinput\fi
@@ -5243,7 +5263,7 @@ end
   Using~the~default~value~'#2'~instead.
 }
 %    \end{macrocode}
-% Sockets for textext.
+% Sockets for tex-text boxes.
 %    \begin{macrocode}
 \socket_new:nn{tagsupport/luamplib/textext/set}{2}
 \socket_new:nn{tagsupport/luamplib/textext/put}{2}
@@ -5310,9 +5330,22 @@ end
 {
   \tag_socket_use:nnn{luamplib/textext/set}
 }
+%    \end{macrocode}
+% For tex-text boxes starting with |[taggingoff]|, which we will not tag at all.
+% They will be just in the artifact MC-chunks.
+%    \begin{macrocode}
+\cs_set_nopar:Npn \luamplibnotagtextboxset #1 #2
+{
+  \bool_set_eq:NN \l_tmpa_bool \l__luamplib_tag_usetext_bool
+  \bool_set_false:N \l__luamplib_tag_usetext_bool
+  \tag_socket_use:nnn{luamplib/textext/set}{#1}{#2}
+  \cs_gset_nopar:cpn {luamplib.notaggedbox.#1}{#1}
+  \bool_set_eq:NN \l__luamplib_tag_usetext_bool \l_tmpa_bool
+}
 \cs_set_nopar:Npn \mplibputtextbox #1
 {
   \vbox to 0pt{\vss\hbox to 0pt{
+    \cs_if_exist:cT {luamplib.notaggedbox.#1}{ \bool_set_false:N \l__luamplib_tag_usetext_bool }
     \socket_use:nnn{tagsupport/luamplib/textext/put}{#1}{\raise\dp#1\copy#1}
   \hss}}
 }

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -5251,12 +5251,10 @@ end
 %    \end{macrocode}
 % TODO: We force an MC. If not, |a| and |b| in |btex a $x$ b etex| are not tagged.
 %    \begin{macrocode}
-    \tag_mc_begin:n{}
-    \tag_tool:n{para/tagging=false}
+    \tag_mc_begin:n{tag=text}
 }
 \socket_new_plug:nnn{tagsupport/luamplib/textext/end}{default}
 {
-    \tag_tool:n{para/tagging=true}
     \tag_mc_end:
     \tag_struct_end:
     \tag_mc_begin_pop:n{}
@@ -5641,39 +5639,39 @@ end
 {
   \prependtomplibbox
   \hbox dir~TLT\bgroup
-  \tag_socket_use:nn{luamplib/figure/begin}\l__luamplib_tag_alt_dflt_tl
-  \xdef\MPllx{#1}\xdef\MPlly{#2}%
-  \xdef\MPurx{#3}\xdef\MPury{#4}%
-  \xdef\MPwidth{\the\dimexpr#3bp-#1bp\relax}%
-  \xdef\MPheight{\the\dimexpr#4bp-#2bp\relax}%
-  \parskip0pt
-  \leftskip0pt
-  \parindent0pt
-  \everypar{}%
-  \setbox\mplibscratchbox\vbox\bgroup
-  \tag_suspend:n{\mplibstarttoPDF}
-  \noindent
+    \tag_socket_use:nn{luamplib/figure/begin}\l__luamplib_tag_alt_dflt_tl
+    \xdef\MPllx{#1}\xdef\MPlly{#2}%
+    \xdef\MPurx{#3}\xdef\MPury{#4}%
+    \xdef\MPwidth{\the\dimexpr#3bp-#1bp\relax}%
+    \xdef\MPheight{\the\dimexpr#4bp-#2bp\relax}%
+    \parskip0pt
+    \leftskip0pt
+    \parindent0pt
+    \everypar{}%
+    \setbox\mplibscratchbox\vbox\bgroup
+      \tag_suspend:n{\mplibstarttoPDF}
+      \noindent
 }
 \cs_set_nopar:Npn \mplibstoptoPDF
 {
-  \par
-  \egroup
-  \setbox\mplibscratchbox\hbox
-    {\hskip-\MPllx bp
-     \raise-\MPlly bp
-     \box\mplibscratchbox}%
-  \setbox\mplibscratchbox\vbox to \MPheight
-    {\vfill
-     \hsize\MPwidth
-     \wd\mplibscratchbox0pt
-     \ht\mplibscratchbox0pt
-     \dp\mplibscratchbox0pt
-     \box\mplibscratchbox}%
-  \wd\mplibscratchbox\MPwidth
-  \ht\mplibscratchbox\MPheight
-  \tag_socket_use:nn{luamplib/figure/bbox}\mplibscratchbox
-  \box\mplibscratchbox
-  \tag_socket_use:n{luamplib/figure/end}
+      \par
+    \egroup
+    \setbox\mplibscratchbox\hbox
+      {\hskip-\MPllx bp
+       \raise-\MPlly bp
+       \box\mplibscratchbox}%
+    \setbox\mplibscratchbox\vbox to \MPheight
+      {\vfill
+       \hsize\MPwidth
+       \wd\mplibscratchbox0pt
+       \ht\mplibscratchbox0pt
+       \dp\mplibscratchbox0pt
+       \box\mplibscratchbox}%
+    \wd\mplibscratchbox\MPwidth
+    \ht\mplibscratchbox\MPheight
+    \tag_socket_use:nn{luamplib/figure/bbox}\mplibscratchbox
+    \box\mplibscratchbox
+    \tag_socket_use:n{luamplib/figure/end}
   \egroup
 }
 \RenewDocumentCommand\mplibcode{O{}}
@@ -5704,15 +5702,15 @@ end
   \tl_set:Nn \l__luamplib_tag_alt_dflt_tl {#2}
   \tag_socket_use:n{luamplib/figure/init}
   \prependtomplibbox\hbox dir~TLT\bgroup
-  \tag_socket_use:nn{luamplib/figure/begin}\l__luamplib_tag_alt_dflt_tl
-  \setbox\mplibscratchbox\hbox\bgroup
-  \tag_socket_use:n{luamplib/mplibgroup/begin}
-  \csname luamplib.group.#2\endcsname
-  \tag_socket_use:n{luamplib/mplibgroup/end}
-  \egroup
-  \tag_socket_use:nn{luamplib/figure/bbox}\mplibscratchbox
-  \unhbox\mplibscratchbox
-  \tag_socket_use:n{luamplib/figure/end}
+    \tag_socket_use:nn{luamplib/figure/begin}\l__luamplib_tag_alt_dflt_tl
+    \setbox\mplibscratchbox\hbox\bgroup
+      \tag_socket_use:n{luamplib/mplibgroup/begin}
+      \csname luamplib.group.#2\endcsname
+      \tag_socket_use:n{luamplib/mplibgroup/end}
+    \egroup
+    \tag_socket_use:nn{luamplib/figure/bbox}\mplibscratchbox
+    \unhbox\mplibscratchbox
+    \tag_socket_use:n{luamplib/figure/end}
   \egroup
   \endgroup
 }

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -557,20 +557,20 @@ See source file '\inFileName' for licencing and contact information.
 %   \hypertarget{taggedPDF}{}\relax
 % When \pkg{tagpdf} package is loaded and activated, |mplibcode| environment accepts additional options for tagged PDF\@.
 % The code related to this functionality is currently in experimental stage, not guaranteeing backward compatibility.
-% Like the \LaTeX's |picture| environment,
+% Similar to the \LaTeX's |picture| environment,
 % available optional keys are |alt|, |actualtext|, |artifact|, |text|, |off|, |correct-BBox|,
 % and |tagging-setup|.
 % (|texdoc| |latex-lab-graphic|).
 % In addition, we also provide the |tag| key.
 % \begin{description}
-% \item[\texttt{tag=\meta{text}}] You can choose a tag name, default value being |Figure|.
-%   BBox info will be added automatically to the PDF
-%   unless the value is |false|, a synonym of the |off| mentioned below.
-% \item[\texttt{alt=\meta{text}}] sets an alternative text of the figure as given.
+% \item[\texttt{alt=}\meta{text}] starts a |Figure| tag by default
+%   (that is, if no |tag| option mentioned below is given) and
+%   sets an alternative text of the figure from the \meta{text}.
+%   BBox info will be added automatically to the PDF\@.
 %   This key is needed for ordinary \metapost figures.
 %   You can change alternative text within \metapost code as well:
 %   |VerbatimTeX| |"\mplibalttext{...}";|
-% \item[\texttt{actualtext=\meta{text}}] starts a |Span| tag implicitly and sets an actualtext as given.
+% \item[\texttt{actualtext=}\meta{text}] starts a |Span| tag implicitly and sets an actualtext from the \meta{text}.
 %   BBox info will not be added.
 %   Horizontal mode is forced by \cs{noindent} or \cs{leavevmode} command
 %   according to the definition of \cs{prependtomplibbox}.\footnote{%
@@ -584,26 +584,31 @@ See source file '\inFileName' for licencing and contact information.
 %   |VerbatimTeX| |"\mplibactualtext{...}";|
 % \item[\texttt{artifact}] starts an |artifact| MC (marked content).
 %   BBox info will not be added.
-%   This key is intended for decorative figures which have no semantic quality.
-% \item[\texttt{text}] starts an |artifact| MC and enables tagging on textext
+%   This key is intended for decorative figures which have no semantic meaning.
+% \item[\texttt{text}] starts an |artifact| MC but enables tagging on textext
 %   (the same as |btex| |...| |etex|) boxes.
 %   BBox info will not be added.
 %   Horizontal mode is forced by \cs{noindent} or \cs{leavevmode} command
 %   according to the definition of \cs{prependtomplibbox}.\footnote{%
 %     |text| key also shares the limitation mentioned in the previous footnote.}
-%   This key is intended for figures made mostly of textext boxes.
-%   Inside text-keyed figures, reusing textext boxes is strongly discouraged.
-% \item[\texttt{off}] Unlike |picture| environment, tagging is deactivated.
-%   It is another but simpler way to declare |tag=false|.
+%   This key is intended for figures the meaning of which can be regarded as a text.
+%   Inside |text|-mode figures, reusing textext boxes is strongly discouraged.
+% \item[\texttt{off}] Unlike the same key of |picture| environment, tagging is deactivated by this option.
+%   It is another but simpler way to declare the option |tag=false|.
 %   Horizontal mode is forced by \cs{noindent} or \cs{leavevmode} command
 %   according to the definition of \cs{prependtomplibbox}.\footnote{%
 %     |off| key also shares the limitation mentioned in the previous footnote.}
-% \item[\texttt{correct-BBox=\meta{dimens}}] You can correct the bounding box of the figure
-%   with space-separated four dimensional values.
-% \item[\texttt{tagging-setup=\meta{key-val list}}]
+% \item[\texttt{tag=}\meta{name}] You can choose a tag name, default value being |Figure|.
+%   BBox info will be added automatically to the PDF
+%   unless the value is |artifact|, |text| or |false|.
+%   |tag=false| is a synonym of the |off| option just mentioned.
+% \item[\texttt{correct-BBox=}\meta{dimens}] You can correct the bounding box of the figure
+%   with space-separated four dimensional values, which will be added to the
+%   automatically-calculated BBox values.
+% \item[\texttt{tagging-setup=}\meta{key-val list}]
 %   This key accepts as its value the list of key-value options mentioned so far.
 % \end{description}
-% To draw the boundingbox of a figure for checking, you can declare |\DocumentMetadata{debug=BBox}|
+% To draw the boundingbox of a figure for checking, you can declare |\DocumentMetadata|\allowbreak|{debug=BBox}|
 % after |\DocumentMetadata{tagging=on}| setup is completed.
 %
 % The above options are provided also for \cs{mpfig} and \cs{usemplibgroup} (see \hyperlink{usemplibgroup}{below} \S\,1.2) commands.
@@ -619,13 +624,13 @@ See source file '\inFileName' for licencing and contact information.
 %     \usemplibgroup[alt=figure drawing a triangle]{...}
 %
 %     \mppattern{...}           % see below
-%       \mpfig[tag=false]       % do not tag this figure
+%       \mpfig[off]             % do not tag this figure
 %       ...
 %       \endmpfig
 %     \endmppattern
 %\end{verbatim}
 % As for the instance name of |mplibcode| environment,
-% |instance=...| or |instancename=...| is also allowed
+% |instance=|\meta{name} or |instancename=|\allowbreak\meta{name} is also allowed
 % in addition to the raw instance name as shown above.
 %
 %
@@ -5476,9 +5481,11 @@ end
     ,off .groups:n = {tagging}
     ,tag .code:n =
       {
-        \str_if_eq:nnTF {#1} {false}
+        \str_case:nnF {#1}
           {
-            \keys_set:nn {luamplib/tag} {off}
+            {false}    { \keys_set:nn {luamplib/tag} {off} }
+            {text}     { \keys_set:nn {luamplib/tag} {text} }
+            {artifact} { \keys_set:nn {luamplib/tag} {artifact} }
           }
           {
             \bool_set_true:N \l__luamplib_tag_BBox_bool

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -563,24 +563,27 @@ See source file '\inFileName' for licencing and contact information.
 % (|texdoc| |latex-lab-graphic|).
 % In addition, we also provide the |tag| key.
 % \begin{description}
-% \item[\texttt{alt=}\meta{text}] starts a |Figure| tag by default
-%   (that is, if no |tag| option mentioned below is given) and
+% \item[\texttt{alt=}\meta{text}] starts a |Figure| tag by default and
 %   sets an alternate text of the figure from the \meta{text}.
 %   BBox info will be added automatically to the PDF\@.
-%   This key is needed for ordinary \metapost figures.
+%   This key is needed for ordinary \metapost figures, for which,
+%   if no |alt| text is given, a default text will be used with a warning issued.
 %   You can change alternate text within \metapost code as well:
 %   |VerbatimTeX| |"\mplibalttext|\marg{text}|";|
-% \item[\texttt{actualtext=}\meta{text}] starts a |Span| tag implicitly and sets an actualtext from the \meta{text}.
+% \item[\texttt{actualtext=}\meta{text}] starts a |Span| tag implicitly and sets an actual text
+%   (that is replacement text) from the \meta{text}.
 %   BBox info will not be added.
 %   Horizontal mode is forced by \cs{noindent} or \cs{leavevmode} command
 %   according to the definition of \cs{prependtomplibbox}.\footnote{%
-%     It is not recommended to personally redefine \cs{prependtomplibbox}.
+%     But the vertical mode will be restored after the mplibcode environment,
+%     if it is started in a vertical mode.
+%     Anyway, it is not recommended to personally redefine \cs{prependtomplibbox}.
 %     Apart from using \cs{mplibforcehmode} or \cs{mplibnoforcehmode},
 %     the redefinition might be incompatible with |actualtext| key.
 %     See \hyperlink{mplibforcehmode}{above} on these commands. }
 %   This key is intended for figures which can be represented by a character or
 %   a small sequence of characters.
-%   You can change actualtext within \metapost code as well:
+%   You can change actual text within \metapost code as well:
 %   |VerbatimTeX| |"\mplibactualtext|\marg{text}|";|
 % \item[\texttt{artifact}] starts an |artifact| MC (marked content).
 %   BBox info will not be added.
@@ -600,11 +603,9 @@ See source file '\inFileName' for licencing and contact information.
 %   according to the definition of \cs{prependtomplibbox}.\footnote{%
 %     |off| key also shares the limitation mentioned in the previous footnote.}
 % \item[\texttt{tag=}\meta{name}] You can choose a tag name, default value being |Figure|.
-%   BBox info will be added automatically to the PDF
-%   unless the value is |artifact|, |text| or |false|.
-%   Among these the last one, |tag=false|, is a synonym of the |off| option just mentioned.
-%   For instance, you can set `|tag=Formula,| |alt=|\meta{text}' to get |Formula| structure
-%   with the alternate text.
+%   For instance, you can set `|tag=Formula,| |alt=|\meta{text} to get
+%   a |Formula| structure with its alternate text.
+%   But when the value is |false|, it is a synonym of the |off| option just mentioned.
 % \item[\texttt{correct-BBox=}\meta{dimens}] You can correct the BBox attribute of the figure
 %   with space-separated four dimensional values, which will be added to the
 %   automatically-calculated BBox values.
@@ -5233,7 +5234,6 @@ end
 \tl_set:Nn\l__luamplib_tag_struct_tl {Figure}
 \bool_new:N \l__luamplib_tag_usetext_bool
 \bool_new:N \g__luamplib_tag_asgroup_bool
-\bool_new:N \l__luamplib_tag_BBox_bool
 \bool_new:N\l__luamplib_tag_bboxcorr_bool
 \seq_new:N\l__luamplib_tag_bboxcorr_seq
 \tl_new:N \l__luamplib_BBox_label_tl
@@ -5350,7 +5350,7 @@ end
 %    \end{macrocode}
 % This socket should be always active.
 %    \begin{macrocode}
-    \UseSocket{tagsupport/luamplib/textext/put}{#1}{\raise\dp#1\copy#1}
+    \socket_use:nnn{tagsupport/luamplib/textext/put}{#1}{\raise\dp#1\copy#1}
   \hss}}
 }
 %    \end{macrocode}
@@ -5437,10 +5437,8 @@ end
 % A socket for BBox attribute
 %    \begin{macrocode}
 \socket_new:nn{tagsupport/luamplib/bbox}{1}
-\socket_new_plug:nnn{tagsupport/luamplib/bbox}{default}
+\socket_new_plug:nnn{tagsupport/luamplib/bbox}{attr}
 {
-  \bool_if:NT \l__luamplib_tag_BBox_bool
-  {
     \tl_set:Ne \l__luamplib_BBox_label_tl {luamplib.BBox.\tag_get:n{struct_num}}
     \tex_savepos:D
     \property_record:ee{\l__luamplib_BBox_label_tl}{xpos,ypos,abspage}
@@ -5543,9 +5541,8 @@ end
           }
         }
       }
-  }
 }
-\socket_assign_plug:nn{tagsupport/luamplib/bbox}{default}
+\socket_assign_plug:nn{tagsupport/luamplib/bbox}{attr}
 %    \end{macrocode}
 % A sockets to force horizontal mode upon |text|, |actualtext|, and |off|
 %    \begin{macrocode}
@@ -5590,7 +5587,6 @@ end
   }
 }
 \socket_new:nn{tagsupport/luamplib/starting}{0}
-\socket_new_plug:nnn{tagsupport/luamplib/starting}{default}{}
 \socket_new_plug:nnn{tagsupport/luamplib/starting}{actualtext}
 {
   \__luamplib_tag_hmode_force:
@@ -5605,7 +5601,7 @@ end
   \__luamplib_tag_hmode_force:
   \tag_suspend:n{luamplib/tag/off}
 }
-\socket_assign_plug:nn{tagsupport/luamplib/starting}{default}
+\socket_assign_plug:nn{tagsupport/luamplib/starting}{noop}
 %    \end{macrocode}
 % Sockets for mplibgroup
 %    \begin{macrocode}
@@ -5636,29 +5632,32 @@ end
   {
     ,alt .code:n =
       {
-        \bool_set_true:N \l__luamplib_tag_BBox_bool
         \tl_set:Ne\l__luamplib_tag_alt_tl{\text_purify:n{#1}}
         \socket_assign_plug:nn{tagsupport/luamplib/begin}{alt}
         \socket_assign_plug:nn{tagsupport/luamplib/end}{alt}
-        \socket_assign_plug:nn{tagsupport/luamplib/starting}{default}
+        \socket_assign_plug:nn{tagsupport/luamplib/bbox}{attr}
+        \socket_assign_plug:nn{tagsupport/luamplib/starting}{noop}
       }
     ,actualtext .code:n =
       {
         \tl_set:Ne\l__luamplib_tag_actual_tl{\text_purify:n{#1}}
         \socket_assign_plug:nn{tagsupport/luamplib/begin}{actualtext}
         \socket_assign_plug:nn{tagsupport/luamplib/end}{actualtext}
+        \socket_assign_plug:nn{tagsupport/luamplib/bbox}{noop}
         \socket_assign_plug:nn{tagsupport/luamplib/starting}{actualtext}
       }
     ,artifact .code:n =
       {
         \socket_assign_plug:nn{tagsupport/luamplib/begin}{artifact}
         \socket_assign_plug:nn{tagsupport/luamplib/end}{artifact}
-        \socket_assign_plug:nn{tagsupport/luamplib/starting}{default}
+        \socket_assign_plug:nn{tagsupport/luamplib/bbox}{noop}
+        \socket_assign_plug:nn{tagsupport/luamplib/starting}{noop}
       }
     ,text .code:n =
       {
         \socket_assign_plug:nn{tagsupport/luamplib/begin}{artifact}
         \socket_assign_plug:nn{tagsupport/luamplib/end}{artifact}
+        \socket_assign_plug:nn{tagsupport/luamplib/bbox}{noop}
         \socket_assign_plug:nn{tagsupport/luamplib/starting}{text}
       }
     ,off .code:n =
@@ -5674,7 +5673,6 @@ end
             {artifact} { \keys_set:nn {luamplib/tag} {artifact} }
           }
           {
-            \bool_set_true:N \l__luamplib_tag_BBox_bool
             \tl_set:Nn\l__luamplib_tag_struct_tl{#1}
           }
       }

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -112,7 +112,7 @@ See source file '\inFileName' for licencing and contact information.
   ItalicFont  = {Linux Libertine O Italic},
   SlantedFont = {Linux Libertine O Italic},
 ]{Linux Libertine O}
-\setmonofont[Scale=MatchLowercase]{InconsolataN}
+\setmonofont[Scale=MatchLowercase,ItalicFont=*]{InconsolataN}
 %setsansfont[Ligatures=TeX]{Linux Biolinum O}
 \setsansfont[UprightFont=*Medium,BoldFont=*Heavy,Ligatures=TeX,Scale=MatchLowercase]{Iwona}
 %setmathfont{XITS Math}
@@ -558,18 +558,19 @@ See source file '\inFileName' for licencing and contact information.
 % When \pkg{tagpdf} package is loaded and activated, |mplibcode| environment accepts additional options for tagged PDF\@.
 % The code related to this functionality is currently in experimental stage, not guaranteeing backward compatibility.
 % Like the \LaTeX's |picture| environment,
-% available optional keys are |tag|, |alt|, |actualtext|, |artifact|, |text|, |off|, |debug| and |correct-BBox|
+% available optional keys are |alt|, |actualtext|, |artifact|, |text|, |off|, |correct-BBox|,
+% and |tagging-setup|.
 % (|texdoc| |latex-lab-graphic|).
+% In addition, we also provide the |tag| key.
 % \begin{description}
-% \item[|tag=...|] You can choose a tag name, default value being |Figure|.
+% \item[\texttt{tag=\meta{text}}] You can choose a tag name, default value being |Figure|.
 %   BBox info will be added automatically to the PDF
-%   unless the value is |artifact|, |text|, |off| or |false|.
-%   When the value is |false|, tagging is deactivated.
-% \item[|alt=...|] sets an alternative text of the figure as given.
+%   unless the value is |false|, a synonym of the |off| mentioned below.
+% \item[\texttt{alt=\meta{text}}] sets an alternative text of the figure as given.
 %   This key is needed for ordinary \metapost figures.
 %   You can change alternative text within \metapost code as well:
 %   |VerbatimTeX| |"\mplibalttext{...}";|
-% \item[|actualtext=...|] starts a |Span| tag implicitly and sets an actualtext as given.
+% \item[\texttt{actualtext=\meta{text}}] starts a |Span| tag implicitly and sets an actualtext as given.
 %   BBox info will not be added.
 %   Horizontal mode is forced by \cs{noindent} or \cs{leavevmode} command
 %   according to the definition of \cs{prependtomplibbox}.\footnote{%
@@ -581,10 +582,10 @@ See source file '\inFileName' for licencing and contact information.
 %   a small sequence of characters.
 %   You can change actualtext within \metapost code as well:
 %   |VerbatimTeX| |"\mplibactualtext{...}";|
-% \item[|artifact|] starts an |artifact| MC (marked content).
+% \item[\texttt{artifact}] starts an |artifact| MC (marked content).
 %   BBox info will not be added.
 %   This key is intended for decorative figures which have no semantic quality.
-% \item[|text|] starts an |artifact| MC and enables tagging on textext
+% \item[\texttt{text}] starts an |artifact| MC and enables tagging on textext
 %   (the same as |btex| |...| |etex|) boxes.
 %   BBox info will not be added.
 %   Horizontal mode is forced by \cs{noindent} or \cs{leavevmode} command
@@ -592,15 +593,20 @@ See source file '\inFileName' for licencing and contact information.
 %     |text| key also shares the limitation mentioned in the previous footnote.}
 %   This key is intended for figures made mostly of textext boxes.
 %   Inside text-keyed figures, reusing textext boxes is strongly discouraged.
-% \item[|off|] luamplib does nothing about tagging.
-%   |mplibcode| remains transprent to the surrounding tagging commands.
-% \item[|debug|] draws the bounding box of the figure for checking.
-% \item[|correct-BBox=...|] You can correct the bounding box of the figure
-%   with space-separated four dimen values.
-% \item[|tagging-setup=...|]
+% \item[\texttt{off}] Unlike |picture| environment, tagging is deactivated.
+%   It is another but simpler way to declare |tag=false|.
+%   Horizontal mode is forced by \cs{noindent} or \cs{leavevmode} command
+%   according to the definition of \cs{prependtomplibbox}.\footnote{%
+%     |off| key also shares the limitation mentioned in the previous footnote.}
+% \item[\texttt{correct-BBox=\meta{dimens}}] You can correct the bounding box of the figure
+%   with space-separated four dimensional values.
+% \item[\texttt{tagging-setup=\meta{key-val list}}]
 %   This key accepts as its value the list of key-value options mentioned so far.
 % \end{description}
-% The above keys are provided also for \cs{mpfig} and \cs{usemplibgroup} (see \hyperlink{usemplibgroup}{below} \S\,1.2) commands.
+% To draw the boundingbox of a figure for checking, you can declare |\DocumentMetadata{debug=BBox}|
+% after |\DocumentMetadata{tagging=on}| setup is completed.
+%
+% The above options are provided also for \cs{mpfig} and \cs{usemplibgroup} (see \hyperlink{usemplibgroup}{below} \S\,1.2) commands.
 %\begin{verbatim}
 %     \begin{mplibcode}[myInstanceName, alt=figure drawing a circle]
 %     ...
@@ -5189,9 +5195,10 @@ end
       ,actualtext   .code:n = { }
       ,artifact     .code:n = { }
       ,text         .code:n = { }
-      ,correct-BBox .code:n = { }
+      ,off          .code:n = { }
       ,tag          .code:n = { }
-      ,debug        .code:n = { }
+      ,correct-BBox .code:n = { }
+      ,tagging-setup .code:n = { }
       ,instance     .code:n = { \tl_gset:Nn \currentmpinstancename {#1} }
       ,instancename .meta:n = { instance = {#1} }
       ,unknown      .code:n = { \tl_gset:Ne \currentmpinstancename {\l_keys_key_str} }
@@ -5219,7 +5226,6 @@ end
 \bool_new:N \l__luamplib_tag_BBox_bool
 \seq_new:N\l__luamplib_tag_bboxcorr_seq
 \bool_new:N\l__luamplib_tag_bboxcorr_bool
-\bool_new:N \l__luamplib_tag_debug_bool
 \tl_new:N \l__luamplib_BBox_label_tl
 \tl_new:N \l__luamplib_BBox_llx_tl
 \tl_new:N \l__luamplib_BBox_lly_tl
@@ -5373,12 +5379,6 @@ end
     \tag_mc_end:
     \tag_mc_begin_pop:n{}
 }
-\NewSocketPlug{tagsupport/luamplib/begin}{transparent}
-{
-}
-\NewSocketPlug{tagsupport/luamplib/end}{transparent}
-{
-}
 \AssignSocketPlug{tagsupport/luamplib/begin}{figure}
 \AssignSocketPlug{tagsupport/luamplib/end}{figure}
 %    \end{macrocode}
@@ -5418,7 +5418,7 @@ end
           }
         \bool_if:NF \l_tmpa_bool
         {
-          \noindent         % prone to an error!
+          \noindent         % prone to error!
           \aftergroup \par
         }
       }
@@ -5438,7 +5438,7 @@ end
 %    \end{macrocode}
 % Key-value options
 %    \begin{macrocode}
-\keys_define:nn{tag/luamplib}
+\keys_define:nn{luamplib/tag}
   {
     ,alt .code:n =
       {
@@ -5470,22 +5470,15 @@ end
     ,text .groups:n = {tagging}
     ,off .code:n =
       {
-        \AssignSocketPlug{tagsupport/luamplib/begin}{transparent}
-        \AssignSocketPlug{tagsupport/luamplib/end}{transparent}
+        \UseTaggingSocket{luamplib/hmode/force}
+        \SuspendTagging{luamplib.tagoff}
       }
     ,off .groups:n = {tagging}
     ,tag .code:n =
       {
-        \str_case:nnF {#1}
+        \str_if_eq:nnTF {#1} {false}
           {
-            {artifact}
-            { \keys_set_known:nn {tag/luamplib} {artifact} }
-            {text}
-            { \keys_set_known:nn {tag/luamplib} {text} }
-            {off}
-            { \keys_set_known:nn {tag/luamplib} {off} }
-            {false}
-            { \SuspendTagging{luamplib.tagfalse} }
+            \keys_set:nn {luamplib/tag} {off}
           }
           {
             \bool_set_true:N \l__luamplib_tag_BBox_bool
@@ -5499,18 +5492,13 @@ end
         \seq_set_split:Nnn \l__luamplib_tag_bboxcorr_seq{~}{#1~0pt~0pt~0pt~0pt}
       }
     ,correct-BBox .groups:n = {tagging}
-    ,debug .code:n =
-      { \bool_set_true:N \l__luamplib_tag_debug_bool }
-    ,debug .groups:n = {tagging}
     ,tagging-setup .code:n =
       {
-        \keys_set_groups:nnn {tag/luamplib} {tagging} {#1}
+        \keys_set_groups:nnn {luamplib/tag} {tagging} {#1}
       }
-    ,instance .code:n =
-      { \tl_gset:Nn \currentmpinstancename {#1} }
+    ,instance .code:n = { \tl_gset:Nn \currentmpinstancename {#1} }
     ,instancename .meta:n = { instance = {#1} }
-    ,unknown .code:n =
-      { \tl_gset:Ne \currentmpinstancename {\l_keys_key_str} }
+    ,unknown .code:n = { \tl_gset:Ne \currentmpinstancename {\l_keys_key_str} }
   }
 %    \end{macrocode}
 % A socket for BBox attribute
@@ -5591,11 +5579,11 @@ end
           \l__luamplib_BBox_ury_tl
         ]
       }
-    \bool_if:NT \l__luamplib_tag_debug_bool
+    \bool_if:NT \l__tag_graphic_debug_bool
       {
         \iow_log:e
           {
-            tag/luamplib~debug:~BBox~of~structure~\tag_get:n{struct_num}~is~
+            luamplib/tag~debug:~BBox~of~structure~\tag_get:n{struct_num}~is~
             \l__luamplib_BBox_llx_tl\c_space_tl
             \l__luamplib_BBox_lly_tl\c_space_tl
             \l__luamplib_BBox_urx_tl\c_space_tl
@@ -5694,7 +5682,7 @@ end
   {
     \tl_set:Nn \l__luamplib_tag_envname_tl {mplibcode}
     \tl_gset_eq:NN \currentmpinstancename \c_empty_tl
-    \keys_set:ne{tag/luamplib}{#1}
+    \keys_set:ne{luamplib/tag}{#1}
     \tl_if_empty:NF \currentmpinstancename
       { \tl_set:Nn\l__luamplib_tag_alt_dflt_tl {metapost~figure~\currentmpinstancename} }
     \mplibtmptoks{}\ltxdomplibcode
@@ -5706,7 +5694,7 @@ end
     {\mplibprempfig *}
     {
       \tl_set:Nn \l__luamplib_tag_envname_tl {mpfig}
-      \keys_set:ne{tag/luamplib}{#2}
+      \keys_set:ne{luamplib/tag}{#2}
       \tl_if_empty:NF \mpfiginstancename
         { \tl_set:Nn\l__luamplib_tag_alt_dflt_tl {metapost~figure~\mpfiginstancename} }
       \mplibmainmpfig
@@ -5716,7 +5704,7 @@ end
   {
     \begingroup
     \tl_set:Nn \l__luamplib_tag_envname_tl {usemplibgroup}
-    \keys_set:ne{tag/luamplib}{#1}
+    \keys_set:ne{luamplib/tag}{#1}
     \tl_set:Nn\l__luamplib_tag_alt_dflt_tl {metapost~figure~#2}
     \prependtomplibbox\hbox dir TLT\bgroup
     \UseTaggingSocket{luamplib/begin}

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -1736,7 +1736,7 @@ local function process_tex_text (str, maketext)
       run_tex_code(format([[\expandafter\newbox\csname luamplib.box.%s\endcsname]], boxid))
       tex_box_id = tex.getcount'allocationnumber'
     end
-    run_tex_code(format("\\luamplibtagtextbegin{%i}%s\\setbox%i\\hbox{%s}\\luamplibtagtextend", tex_box_id, global, tex_box_id, str))
+    run_tex_code(format("\\luamplibtagtextboxset{%i}{%s\\setbox%i\\hbox{%s}}", tex_box_id, global, tex_box_id, str))
     local box = texgetbox(tex_box_id)
     local wd  = box.width  / factor
     local ht  = box.height / factor
@@ -4128,7 +4128,7 @@ local function do_preobj_GRP (object, prescript)
       trgroup[v] = true
     end
     trgroup.bbox = prescript.mplibgroupbbox:explode":"
-    put2output[[\begingroup\setbox\mplibscratchbox\hbox\bgroup\luamplibtagasgroupinit]]
+    put2output[[\begingroup\setbox\mplibscratchbox\hbox\bgroup\luamplibtagasgroupset]]
   elseif grstate == "stop" then
     local llx,lly,urx,ury = tableunpack(trgroup.bbox)
     put2output(tableconcat{
@@ -5179,10 +5179,9 @@ end
 %
 %    Code for \pkg{tagpdf}
 %    \begin{macrocode}
-\def\luamplibtagtextbegin#1{}
-\let\luamplibtagtextend\relax
-\let\luamplibtagasgroupinit\relax
-\def\luamplibtagasgroupput#1#2{#2}
+\def\luamplibtagtextboxset#1#2{#2}
+\let\luamplibtagasgroupset\relax
+\let\luamplibtagasgroupput\luamplibtagtextboxset
 \ifcsname SuspendTagging\endcsname\else\endinput\fi
 \ifcsname ver@tagpdf.sty\endcsname \else
   \ExplSyntaxOn
@@ -5206,9 +5205,9 @@ end
       \keys_set:ne{luamplib/notagging}{#1}
       \mplibtmptoks{}\ltxdomplibcode
     }
+  \cs_set_eq:NN \mplibalttext \use_none:n
+  \cs_set_eq:NN \mplibactualtext \use_none:n
   \ExplSyntaxOff
-  \let\mplibalttext \luamplibtagtextbegin
-  \let\mplibactualtext \mplibalttext
   \endinput\fi
 \ExplSyntaxOn
 \tl_new:N \l__luamplib_tag_envname_tl
@@ -5228,13 +5227,13 @@ end
 \msg_new:nnn {luamplib}{figure-text-reuse}
 {
   tex-text~box~#1~probably~is~incorrectly~tagged.~
-  Reusing~a~box~from~non-text~mode~is~strongly~discouraged.~
+  Reusing~a~box~from~non-text~mode~is~not~recommended.~
   Check~the~resulting~PDF.
 }
 \msg_new:nnn {luamplib}{mplibgroup-text-mode}
 {
   mplibgroup/asgroup~'#1'~probably~is~incorrectly~tagged.~
-  Using~mplibgroup/asgroup~with~text~mode~is~strongly~discouraged.~
+  Using~mplibgroup/asgroup~with~text~mode~is~not~recommended.~
   Check~the~resulting~PDF.
 }
 \msg_new:nnn{luamplib}{alt-text-missing}
@@ -5243,13 +5242,17 @@ end
   Using~the~default~value~'#2'~instead.
 }
 %    \end{macrocode}
-% Sockets for textext
+% Sockets for textext.\\
+% TODO: we check |text| mode here.
+% If we tag text boxes for all modes, we will get a lot of structure-has-no-parent warning;
+% no good-looking, though it seems to be no harm.
 %    \begin{macrocode}
-\socket_new:nn{tagsupport/luamplib/textext/begin}{1}
-\socket_new:nn{tagsupport/luamplib/textext/end}{0}
+\socket_new:nn{tagsupport/luamplib/textext/set}{2}
 \socket_new:nn{tagsupport/luamplib/textext/put}{2}
-\socket_new_plug:nnn{tagsupport/luamplib/textext/begin}{default}
+\socket_new_plug:nnn{tagsupport/luamplib/textext/set}{default}
 {
+  \bool_if:NTF \l__luamplib_tag_usetext_bool
+  {
     \tag_mc_end_push:
     \tag_struct_begin:n{tag=NonStruct, stash, parent-tag=text}
     \cs_gset_nopar:cpe {luamplib.taggedbox.#1} {\tag_get:n{struct_num}}
@@ -5257,12 +5260,16 @@ end
 % TODO: We force an MC. Otherwize |a| and |b| in |btex a $x$ b etex| are not tagged.
 %    \begin{macrocode}
     \tag_mc_begin:n{tag=text}
-}
-\socket_new_plug:nnn{tagsupport/luamplib/textext/end}{default}
-{
+    #2
     \tag_mc_end:
     \tag_struct_end:
     \tag_mc_begin_pop:n{}
+  }
+  {
+    \tag_suspend:n{\luamplibtagtextboxset}
+    #2
+    \tag_resume:n{\luamplibtagtextboxset}
+  }
 }
 \socket_new_plug:nnn{tagsupport/luamplib/textext/put}{default}
 {
@@ -5282,34 +5289,11 @@ end
     }
     \tag_mc_begin:n{artifact}
 }
-\socket_assign_plug:nn{tagsupport/luamplib/textext/begin}{default}
-\socket_assign_plug:nn{tagsupport/luamplib/textext/end}{default}
+\socket_assign_plug:nn{tagsupport/luamplib/textext/set}{default}
 \socket_assign_plug:nn{tagsupport/luamplib/textext/put}{default}
-\cs_set_nopar:Npn \luamplibtagtextbegin #1
+\cs_set_nopar:Npn \luamplibtagtextboxset
 {
-%    \end{macrocode}
-% TODO: we check |text| mode here.
-% If the sockets are used for all modes, we will get a lot of structure-has-no-parent warning;
-% no good-looking, though it seems to be no harm.
-%    \begin{macrocode}
-  \bool_if:NTF \l__luamplib_tag_usetext_bool
-  {
-    \tag_socket_use:nn{luamplib/textext/begin}{#1}
-  }
-  {
-    \bool_set:Nn \l_tmpa_bool { \tag_if_active_p: }
-    \tag_suspend:n{\luamplibtagtextbegin}
-  }
-}
-\cs_set_nopar:Npn \luamplibtagtextend
-{
-  \bool_if:NTF \l__luamplib_tag_usetext_bool
-  {
-    \tag_socket_use:n{luamplib/textext/end}
-  }
-  {
-    \bool_if:NT \l_tmpa_bool { \tag_resume:n{\luamplibtagtextend} }
-  }
+  \tag_socket_use:nnn{luamplib/textext/set}
 }
 \cs_set_nopar:Npn \mplibputtextbox #1
 {
@@ -5330,14 +5314,14 @@ end
 % TODO: Not sure whether asgroup/mplibgroup with |text| mode will be tagged correctly.
 %       Probably not. At least, this will raise a warning.
 %    \begin{macrocode}
-\cs_set_nopar:Npn \luamplibtagasgroupinit
+\cs_set_nopar:Npn \luamplibtagasgroupset
 {
   \bool_set_false:N \l__luamplib_tag_usetext_bool
 }
-\cs_set_nopar:Npn \luamplibtagasgroupput #1 #2
+\cs_set_nopar:Npn \luamplibtagasgroupput
 {
   \bool_if:NT \l__luamplib_tag_usetext_bool { \tag_resume:n{\luamplibtagasgroupput} }
-  \tag_socket_use:nnn{luamplib/mplibgroup/put}{#1}{#2}
+  \tag_socket_use:nnn{luamplib/mplibgroup/put}
 }
 %    \end{macrocode}
 % A socket for mplibgroup. Again, we issue a warning upon |text| mode.

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -658,9 +658,10 @@ See source file '\inFileName' for licencing and contact information.
 %   (see \hyperlink{mpliboutlinetext}{below}).
 %   However the syntax is somewhat different.
 %\begin{verbatim}
-%     mplibgraphictext "Funny"
+%     draw mplibgraphictext "Funny"
 %       fakebold 2.3                        % fontspec option
 %       drawcolor .7blue fillcolor "red!50" % color expressions
+%       ;
 %\end{verbatim}
 %   |fakebold|, |drawcolor| and |fillcolor| are optional;
 %   default values are |2|, |"black"| and |"white"| respectively.
@@ -678,12 +679,11 @@ See source file '\inFileName' for licencing and contact information.
 %   such as the vertical writing in Chinese or Japanese.
 %   However, because the implementation is quite different from others,
 %   there are some limitations such that you can't
-%   apply shading (gradient colors) to the text with |withshademethod| from
-%   \emph{metafun}.\footnote{But
-%   this limitation is now lifted by the introduction of |withshadingmethod|.
-%   See \hyperlink{luamplibshading}{below}.}
+%   apply shading (gradient colors) to the text with \emph{metafun}'s |withshademethod|.\relax
+%   \footnote{But this limitation is now lifted by the introduction of |withshadingmethod|.
+%     See \hyperlink{luamplibshading}{below}.}
 %   Again,
-%   in DVI mode, \pkg{unicode-math} package is needed for math formula,
+%   in DVI mode, \pkg{unicode-math} package is needed for math formulae,
 %   as we cannot embolden type1 fonts in DVI mode.
 %
 %   \subsubsection{\texttt{mplibglyph ... of ...}}
@@ -4144,12 +4144,11 @@ local function do_preobj_GRP (object, prescript)
       put2output(tableconcat{
         "\\saveboxresource type 2 attr{/Type/XObject/Subtype/Form/FormType 1",
         "/BBox[", bbox, "]", grattr, "} resources{", res, "}\\mplibscratchbox",
-        "\\luamplibtagasgroupbegin",
+        "\\luamplibtagasgroupput{",trgroup.name,"}{",
         [[\setbox\mplibscratchbox\hbox{\useboxresource\lastsavedboxresourceindex}]],
         [[\wd\mplibscratchbox 0pt\ht\mplibscratchbox 0pt\dp\mplibscratchbox 0pt]],
         [[\box\mplibscratchbox]],
-        "\\luamplibtagasgroupend",
-        "\\endgroup",
+        "}\\endgroup",
         "\\expandafter\\xdef\\csname luamplib.group.", trgroup.name, "\\endcsname{",
         "\\setbox\\mplibscratchbox\\hbox{\\hskip",-llx,"bp\\raise",-lly,"bp\\hbox{",
         "\\useboxresource \\the\\lastsavedboxresourceindex",
@@ -4164,8 +4163,9 @@ local function do_preobj_GRP (object, prescript)
         "\\unhbox\\mplibscratchbox",
         "\\special{pdf:put @resources <<", res, ">>}",
         "\\special{pdf:exobj <<", grattr, ">>}",
+        "\\luamplibtagasgroupput{",trgroup.name,"}{",
         "\\special{pdf:uxobj ", objname, "}",
-        "\\endgroup",
+        "}\\endgroup",
       })
       token.set_macro("luamplib.group."..trgroup.name, tableconcat{
         "\\setbox\\mplibscratchbox\\hbox{\\hskip",-llx,"bp\\raise",-lly,"bp\\hbox{",
@@ -5182,8 +5182,7 @@ end
 \def\luamplibtagtextbegin#1{}
 \let\luamplibtagtextend\relax
 \let\luamplibtagasgroupinit\relax
-\let\luamplibtagasgroupbegin\relax
-\let\luamplibtagasgroupend\relax
+\def\luamplibtagasgroupput#1#2{#2}
 \ifcsname SuspendTagging\endcsname\else\endinput\fi
 \ifcsname ver@tagpdf.sty\endcsname \else
   \ExplSyntaxOn
@@ -5234,8 +5233,8 @@ end
 }
 \msg_new:nnn {luamplib}{mplibgroup-text-mode}
 {
-  mplibgroup~'#1'~probably~is~incorrectly~tagged.~
-  Using~mplibgroup~in~text~mode~is~strongly~discouraged.~
+  mplibgroup/asgroup~'#1'~probably~is~incorrectly~tagged.~
+  Using~mplibgroup/asgroup~with~text~mode~is~strongly~discouraged.~
   Check~the~resulting~PDF.
 }
 \msg_new:nnn{luamplib}{alt-text-missing}
@@ -5289,8 +5288,8 @@ end
 \cs_set_nopar:Npn \luamplibtagtextbegin #1
 {
 %    \end{macrocode}
-% TODO: we test |text| mode here.
-% If the socket is used for all modes, we will get a lot of structure-has-no-parent warning;
+% TODO: we check |text| mode here.
+% If the sockets are used for all modes, we will get a lot of structure-has-no-parent warning;
 % no good-looking, though it seems to be no harm.
 %    \begin{macrocode}
   \bool_if:NTF \l__luamplib_tag_usetext_bool
@@ -5328,59 +5327,36 @@ end
   \hss}}
 }
 %    \end{macrocode}
-% TODO: Not sure whether asgroup/mplibgroup will be tagged correctly. Probably not.
-%       At least, this will raise a warning.
+% TODO: Not sure whether asgroup/mplibgroup with |text| mode will be tagged correctly.
+%       Probably not. At least, this will raise a warning.
 %    \begin{macrocode}
 \cs_set_nopar:Npn \luamplibtagasgroupinit
 {
   \bool_set_false:N \l__luamplib_tag_usetext_bool
 }
-\cs_set_nopar:Npn \luamplibtagasgroupbegin
+\cs_set_nopar:Npn \luamplibtagasgroupput #1 #2
 {
-  \bool_if:NT \l__luamplib_tag_usetext_bool
-  {
-    \tag_resume:n{\luamplibtagasgroupbegin}
-    \tag_mc_end:
-    \tag_mc_begin:n{}
-  }
-}
-\cs_set_nopar:Npn \luamplibtagasgroupend
-{
-  \bool_if:NT \l__luamplib_tag_usetext_bool
-  {
-    \tag_mc_end:
-    \tag_mc_begin:n{artifact}
-    \tag_suspend:n{\luamplibtagasgroupend}
-  }
+  \bool_if:NT \l__luamplib_tag_usetext_bool { \tag_resume:n{\luamplibtagasgroupput} }
+  \tag_socket_use:nnn{luamplib/mplibgroup/put}{#1}{#2}
 }
 %    \end{macrocode}
-% Sockets for mplibgroup
+% A socket for mplibgroup. Again, we issue a warning upon |text| mode.
 %    \begin{macrocode}
-\socket_new:nn{tagsupport/luamplib/mplibgroup/begin}{1}
-\socket_new:nn{tagsupport/luamplib/mplibgroup/end}{0}
-\socket_new_plug:nnn{tagsupport/luamplib/mplibgroup/begin}{default}
+\socket_new:nn{tagsupport/luamplib/mplibgroup/put}{2}
+\socket_new_plug:nnn{tagsupport/luamplib/mplibgroup/put}{default}
 {
-    \bool_if:NT \l__luamplib_tag_usetext_bool
-    {
-      \cs_if_free:cT {luamplib.mplibgroup.text.#1}
-      {
-        \msg_warning:nnn {luamplib} {mplibgroup-text-mode} {#1}
-        \cs_gset_nopar:cpn {luamplib.mplibgroup.text.#1} {#1}
-      }
-      \tag_mc_end:
-      \tag_mc_begin:n{}
-    }
+  \cs_if_free:cT {luamplib.mplibgroup.text.#1}
+  {
+    \msg_warning:nnn {luamplib} {mplibgroup-text-mode} {#1}
+    \cs_gset_nopar:cpn {luamplib.mplibgroup.text.#1} {#1}
+  }
+  \tag_mc_end:
+  \tag_mc_begin:n{}
+  #2
+  \tag_mc_end:
+  \tag_mc_begin:n{artifact}
 }
-\socket_new_plug:nnn{tagsupport/luamplib/mplibgroup/end}{default}
-{
-    \bool_if:NT \l__luamplib_tag_usetext_bool
-    {
-      \tag_mc_end:
-      \tag_mc_begin:n{artifact}
-    }
-}
-\socket_assign_plug:nn{tagsupport/luamplib/mplibgroup/begin}{default}
-\socket_assign_plug:nn{tagsupport/luamplib/mplibgroup/end}{default}
+\socket_assign_plug:nn{tagsupport/luamplib/mplibgroup/put}{default}
 %    \end{macrocode}
 % A macro for BBox attribute
 %    \begin{macrocode}
@@ -5507,10 +5483,7 @@ end
 %    \begin{macrocode}
 \socket_new:nn{tagsupport/luamplib/figure/begin}{1}
 \socket_new:nn{tagsupport/luamplib/figure/end}{2}
-\cs_if_free:NT \NewTaggingSocket
-{
-  \socket_new_plug:nnn{tagsupport/luamplib/figure/end}{transparent}{#2}
-}
+\socket_new_plug:nnn{tagsupport/luamplib/figure/end}{transparent}{#2}
 \socket_new_plug:nnn{tagsupport/luamplib/figure/begin}{alt}
 {
     \tag_mc_end_push:
@@ -5567,7 +5540,8 @@ end
     \tag_mc_begin_pop:n{}
 }
 %    \end{macrocode}
-% A socket for tagging init
+% A socket for tagging init, so that we can declare
+% |\keys_set:nn{luamplib/tagging}{...}| anywhere in the document.
 %    \begin{macrocode}
 \socket_new:nn{tagsupport/luamplib/figure/init}{0}
 \socket_new_plug:nnn{tagsupport/luamplib/figure/init}{alt}
@@ -5711,16 +5685,16 @@ end
   \prependtomplibbox\hbox dir~TLT\bgroup
     \tag_socket_use:nn{luamplib/figure/begin}{#2}
     \setbox\mplibscratchbox\hbox\bgroup
-      \tag_socket_use:n{luamplib/mplibgroup/begin}{#2}
-      \csname luamplib.group.#2\endcsname
-      \tag_socket_use:n{luamplib/mplibgroup/end}
+      \bool_if:NF \l__luamplib_tag_usetext_bool { \tag_suspend:n{\usemplibgroup} }
+      \tag_socket_use:nnn{luamplib/mplibgroup/put}{#2}{\csname luamplib.group.#2\endcsname}
     \egroup
     \tag_socket_use:nnn{luamplib/figure/end}{\mplibscratchbox}{\unhbox\mplibscratchbox}
   \egroup
   \endgroup
 }
 %    \end{macrocode}
-% Allow setting alt/actual text within \metapost code
+% Allow setting alt/actual text within \metapost code.
+% Of course we can use them in \TeX\ code as well.
 %    \begin{macrocode}
 \cs_new_nopar:Npn \mplibalttext #1
 {

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -1736,7 +1736,8 @@ local function process_tex_text (str, maketext)
       run_tex_code(format([[\expandafter\newbox\csname luamplib.box.%s\endcsname]], boxid))
       tex_box_id = tex.getcount'allocationnumber'
     end
-    run_tex_code(format("\\luamplibtagtextboxset{%i}{%s\\setbox%i\\hbox{%s}}", tex_box_id, global, tex_box_id, str))
+    run_tex_code(format("\\luamplibtagtextboxset{%i}{%s\\setbox%i\\hbox{%s}}",
+                        tex_box_id, global, tex_box_id, str))
     local box = texgetbox(tex_box_id)
     local wd  = box.width  / factor
     local ht  = box.height / factor
@@ -5242,19 +5243,23 @@ end
   Using~the~default~value~'#2'~instead.
 }
 %    \end{macrocode}
-% Sockets for textext.\\
-% TODO: we check |text| mode here.
-% If we tag text boxes for all modes, we will get a lot of structure-has-no-parent warning;
-% no good-looking, though it seems to be no harm.
+% Sockets for textext.
 %    \begin{macrocode}
 \socket_new:nn{tagsupport/luamplib/textext/set}{2}
 \socket_new:nn{tagsupport/luamplib/textext/put}{2}
 \socket_new_plug:nnn{tagsupport/luamplib/textext/set}{default}
 {
+%    \end{macrocode}
+% TODO: we check |text| mode here.
+% If we tag text boxes for all modes, we will get a lot of structure-has-no-parent warning;
+% no good-looking, though it seems to be no harm.
+%    \begin{macrocode}
   \bool_if:NTF \l__luamplib_tag_usetext_bool
   {
     \tag_mc_end_push:
-    \tag_struct_begin:n{tag=NonStruct, stash, parent-tag=text}
+    \keys_if_exist:nnTF {__tag/struct} {parent-tag}
+      { \tag_struct_begin:n{tag=NonStruct, stash, parent-tag=text} }
+      { \tag_struct_begin:n{tag=NonStruct, stash} }
     \cs_gset_nopar:cpe {luamplib.taggedbox.#1} {\tag_get:n{struct_num}}
 %    \end{macrocode}
 % TODO: We force an MC. Otherwize |a| and |b| in |btex a $x$ b etex| are not tagged.
@@ -5273,6 +5278,9 @@ end
 }
 \socket_new_plug:nnn{tagsupport/luamplib/textext/put}{default}
 {
+  \bool_if:NTF \l__luamplib_tag_usetext_bool
+  {
+    \tag_resume:n{\mplibputtextbox}
     \tag_mc_end:
     \cs_if_exist:cTF {luamplib.taggedbox.#1}
     {
@@ -5288,6 +5296,12 @@ end
       \tag_mc_end:
     }
     \tag_mc_begin:n{artifact}
+  }
+  {
+    \int_set:Nn \l_tmpa_int {#1}
+    \tag_mc_reset_box:N \l_tmpa_int
+    #2
+  }
 }
 \socket_assign_plug:nn{tagsupport/luamplib/textext/set}{default}
 \socket_assign_plug:nn{tagsupport/luamplib/textext/put}{default}
@@ -5298,16 +5312,7 @@ end
 \cs_set_nopar:Npn \mplibputtextbox #1
 {
   \vbox to 0pt{\vss\hbox to 0pt{
-    \bool_if:NTF \l__luamplib_tag_usetext_bool
-    {
-      \tag_resume:n{\mplibputtextbox}
-      \tag_socket_use:nnn{luamplib/textext/put}{#1}{\raise\dp#1\copy#1}
-    }
-    {
-      \int_set:Nn \l_tmpa_int {#1}
-      \tag_mc_reset_box:N \l_tmpa_int
-      \raise\dp#1\copy#1
-    }
+    \socket_use:nnn{tagsupport/luamplib/textext/put}{#1}{\raise\dp#1\copy#1}
   \hss}}
 }
 %    \end{macrocode}

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -5248,8 +5248,7 @@ end
 %    \begin{macrocode}
 \socket_new:nn{tagsupport/luamplib/textext/begin}{1}
 \socket_new:nn{tagsupport/luamplib/textext/end}{0}
-\socket_new:nn{tagsupport/luamplib/textext/put/begin}{1}
-\socket_new:nn{tagsupport/luamplib/textext/put/end}{1}
+\socket_new:nn{tagsupport/luamplib/textext/put}{2}
 \socket_new_plug:nnn{tagsupport/luamplib/textext/begin}{default}
 {
     \tag_mc_end_push:
@@ -5266,7 +5265,7 @@ end
     \tag_struct_end:
     \tag_mc_begin_pop:n{}
 }
-\socket_new_plug:nnn{tagsupport/luamplib/textext/put/begin}{default}
+\socket_new_plug:nnn{tagsupport/luamplib/textext/put}{default}
 {
   \bool_if:NTF \l__luamplib_tag_usetext_bool
   {
@@ -5274,34 +5273,27 @@ end
     \cs_if_exist:cTF {luamplib.taggedbox.#1}
     {
       \exp_args:Nc \tag_struct_use_num:n {luamplib.taggedbox.#1}
+      #2
     }
     {
       \msg_warning:nnn{luamplib}{figure-text-reuse}{#1}
       \tag_mc_begin:n{}
       \int_set:Nn \l_tmpa_int {#1}
       \tag_mc_reset_box:N \l_tmpa_int
-    }
-  }
-  {
-    \int_set:Nn \l_tmpa_int {#1}
-    \tag_mc_reset_box:N \l_tmpa_int
-  }
-}
-\socket_new_plug:nnn{tagsupport/luamplib/textext/put/end}{default}
-{
-  \bool_if:NT \l__luamplib_tag_usetext_bool
-  {
-    \cs_if_exist:cF {luamplib.taggedbox.#1}
-    {
+      #2
       \tag_mc_end:
     }
     \tag_mc_begin:n{artifact}
   }
+  {
+    \int_set:Nn \l_tmpa_int {#1}
+    \tag_mc_reset_box:N \l_tmpa_int
+    #2
+  }
 }
 \socket_assign_plug:nn{tagsupport/luamplib/textext/begin}{default}
 \socket_assign_plug:nn{tagsupport/luamplib/textext/end}{default}
-\socket_assign_plug:nn{tagsupport/luamplib/textext/put/begin}{default}
-\socket_assign_plug:nn{tagsupport/luamplib/textext/put/end}{default}
+\socket_assign_plug:nn{tagsupport/luamplib/textext/put}{default}
 \cs_set_nopar:Npn \luamplibtagtextbegin #1
 {
 %    \end{macrocode}
@@ -5332,9 +5324,7 @@ end
 {
   \vbox to 0pt{\vss\hbox to 0pt{
     \tag_resume:n{\mplibputtextbox}
-    \tag_socket_use:nn{luamplib/textext/put/begin}{#1}
-    \raise\dp#1\copy#1
-    \tag_socket_use:nn{luamplib/textext/put/end}{#1}
+    \tag_socket_use:nnn{luamplib/textext/put}{#1}{\raise\dp#1\copy#1}
   \hss}}
 }
 %    \end{macrocode}
@@ -5392,66 +5382,9 @@ end
 \socket_assign_plug:nn{tagsupport/luamplib/mplibgroup/begin}{default}
 \socket_assign_plug:nn{tagsupport/luamplib/mplibgroup/end}{default}
 %    \end{macrocode}
-% Sockets for main process
+% A macro for BBox attribute
 %    \begin{macrocode}
-\socket_new:nn{tagsupport/luamplib/figure/begin}{1}
-\socket_new:nn{tagsupport/luamplib/figure/end}{0}
-\socket_new_plug:nnn{tagsupport/luamplib/figure/begin}{alt}
-{
-    \tag_mc_end_push:
-    \tl_if_empty:NT\l__luamplib_tag_alt_tl
-    {
-      \tl_if_empty:eTF{#1}
-        { \tl_set:Nn \l__luamplib_tag_alt_tl {metapost~figure} }
-        { \tl_set:Ne \l__luamplib_tag_alt_tl {metapost~figure~\text_purify:n{#1}} }
-      \msg_warning:nnVV{luamplib}{alt-text-missing}
-                       \l__luamplib_tag_envname_tl \l__luamplib_tag_alt_tl
-    }
-    \tag_struct_begin:n
-    {
-      tag=\l__luamplib_tag_struct_tl,
-      alt=\l__luamplib_tag_alt_tl,
-    }
-    \tag_mc_begin:n{}
-}
-\socket_new_plug:nnn{tagsupport/luamplib/figure/end}{alt}
-{
-    \tl_use:N \l__luamplib_tag_bbox_draw_tl
-    \tag_mc_end:
-    \tag_struct_end:
-    \tag_mc_begin_pop:n{}
-}
-\socket_new_plug:nnn{tagsupport/luamplib/figure/begin}{actualtext}
-{
-    \tag_mc_end_push:
-    \tag_struct_begin:n
-    {
-      tag=Span,
-      actualtext=\l__luamplib_tag_actual_tl,
-    }
-    \tag_mc_begin:n{}
-}
-\socket_new_plug:nnn{tagsupport/luamplib/figure/end}{actualtext}
-{
-    \tag_mc_end:
-    \tag_struct_end:
-    \tag_mc_begin_pop:n{}
-}
-\socket_new_plug:nnn{tagsupport/luamplib/figure/begin}{artifact}
-{
-    \tag_mc_end_push:
-    \tag_mc_begin:n{artifact}
-}
-\socket_new_plug:nnn{tagsupport/luamplib/figure/end}{artifact}
-{
-    \tag_mc_end:
-    \tag_mc_begin_pop:n{}
-}
-%    \end{macrocode}
-% A socket for BBox attribute
-%    \begin{macrocode}
-\socket_new:nn{tagsupport/luamplib/figure/bbox}{1}
-\socket_new_plug:nnn{tagsupport/luamplib/figure/bbox}{alt}
+\cs_set_nopar:Npn \luamplib_tag_bbox_attribute:n #1
 {
   \tl_set:Ne \l_tmpa_tl {luamplib.BBox.\tag_get:n{struct_num}}
   \tex_savepos:D
@@ -5551,7 +5484,7 @@ end
   }
 }
 %    \end{macrocode}
-% horizontal mode upon |text| and |actualtext|
+% Macros for para tagging upon |text| and |actualtext|
 %    \begin{macrocode}
 \cs_set_nopar:Npn \__luamplib_tag_pseudo_para_begin:
 {
@@ -5570,6 +5503,70 @@ end
   }
 }
 %    \end{macrocode}
+% Sockets for main process
+%    \begin{macrocode}
+\socket_new:nn{tagsupport/luamplib/figure/begin}{1}
+\socket_new:nn{tagsupport/luamplib/figure/end}{2}
+\cs_if_free:NT \NewTaggingSocket
+{
+  \socket_new_plug:nnn{tagsupport/luamplib/figure/end}{transparent}{#2}
+}
+\socket_new_plug:nnn{tagsupport/luamplib/figure/begin}{alt}
+{
+    \tag_mc_end_push:
+    \tl_if_empty:NT\l__luamplib_tag_alt_tl
+    {
+      \tl_if_empty:eTF{#1}
+        { \tl_set:Nn \l__luamplib_tag_alt_tl {metapost~figure} }
+        { \tl_set:Ne \l__luamplib_tag_alt_tl {metapost~figure~\text_purify:n{#1}} }
+      \msg_warning:nnVV{luamplib}{alt-text-missing}
+                       \l__luamplib_tag_envname_tl \l__luamplib_tag_alt_tl
+    }
+    \tag_struct_begin:n
+    {
+      tag=\l__luamplib_tag_struct_tl,
+      alt=\l__luamplib_tag_alt_tl,
+    }
+    \tag_mc_begin:n{}
+}
+\socket_new_plug:nnn{tagsupport/luamplib/figure/end}{alt}
+{
+    \luamplib_tag_bbox_attribute:n {#1}
+    #2
+    \tl_use:N \l__luamplib_tag_bbox_draw_tl
+    \tag_mc_end:
+    \tag_struct_end:
+    \tag_mc_begin_pop:n{}
+}
+\socket_new_plug:nnn{tagsupport/luamplib/figure/begin}{actualtext}
+{
+    \tag_mc_end_push:
+    \tag_struct_begin:n
+    {
+      tag=Span,
+      actualtext=\l__luamplib_tag_actual_tl,
+    }
+    \tag_mc_begin:n{}
+}
+\socket_new_plug:nnn{tagsupport/luamplib/figure/end}{actualtext}
+{
+    #2
+    \tag_mc_end:
+    \tag_struct_end:
+    \tag_mc_begin_pop:n{}
+}
+\socket_new_plug:nnn{tagsupport/luamplib/figure/begin}{artifact}
+{
+    \tag_mc_end_push:
+    \tag_mc_begin:n{artifact}
+}
+\socket_new_plug:nnn{tagsupport/luamplib/figure/end}{artifact}
+{
+    #2
+    \tag_mc_end:
+    \tag_mc_begin_pop:n{}
+}
+%    \end{macrocode}
 % A socket for tagging init
 %    \begin{macrocode}
 \socket_new:nn{tagsupport/luamplib/figure/init}{0}
@@ -5577,34 +5574,29 @@ end
 {
   \socket_assign_plug:nn{tagsupport/luamplib/figure/begin}{alt}
   \socket_assign_plug:nn{tagsupport/luamplib/figure/end}{alt}
-  \socket_assign_plug:nn{tagsupport/luamplib/figure/bbox}{alt}
 }
 \socket_new_plug:nnn{tagsupport/luamplib/figure/init}{actualtext}
 {
   \socket_assign_plug:nn{tagsupport/luamplib/figure/begin}{actualtext}
   \socket_assign_plug:nn{tagsupport/luamplib/figure/end}{actualtext}
-  \socket_assign_plug:nn{tagsupport/luamplib/figure/bbox}{noop}
   \__luamplib_tag_pseudo_para_begin:
 }
 \socket_new_plug:nnn{tagsupport/luamplib/figure/init}{artifact}
 {
   \socket_assign_plug:nn{tagsupport/luamplib/figure/begin}{artifact}
   \socket_assign_plug:nn{tagsupport/luamplib/figure/end}{artifact}
-  \socket_assign_plug:nn{tagsupport/luamplib/figure/bbox}{noop}
 }
 \socket_new_plug:nnn{tagsupport/luamplib/figure/init}{text}
 {
   \bool_set_true:N \l__luamplib_tag_usetext_bool
   \socket_assign_plug:nn{tagsupport/luamplib/figure/begin}{artifact}
   \socket_assign_plug:nn{tagsupport/luamplib/figure/end}{artifact}
-  \socket_assign_plug:nn{tagsupport/luamplib/figure/bbox}{noop}
   \__luamplib_tag_pseudo_para_begin:
 }
 \socket_new_plug:nnn{tagsupport/luamplib/figure/init}{off}
 {
   \socket_assign_plug:nn{tagsupport/luamplib/figure/begin}{noop}
-  \socket_assign_plug:nn{tagsupport/luamplib/figure/end}{noop}
-  \socket_assign_plug:nn{tagsupport/luamplib/figure/bbox}{noop}
+  \socket_assign_plug:nn{tagsupport/luamplib/figure/end}{transparent}
 }
 \socket_assign_plug:nn{tagsupport/luamplib/figure/init}{alt}
 %    \end{macrocode}
@@ -5687,9 +5679,7 @@ end
        \box\mplibscratchbox}%
     \wd\mplibscratchbox\MPwidth
     \ht\mplibscratchbox\MPheight
-    \tag_socket_use:nn{luamplib/figure/bbox}\mplibscratchbox
-    \box\mplibscratchbox
-    \tag_socket_use:n{luamplib/figure/end}
+    \tag_socket_use:nnn{luamplib/figure/end}{\mplibscratchbox}{\box\mplibscratchbox}
   \egroup
 }
 \RenewDocumentCommand\mplibcode{O{}}
@@ -5725,9 +5715,7 @@ end
       \csname luamplib.group.#2\endcsname
       \tag_socket_use:n{luamplib/mplibgroup/end}
     \egroup
-    \tag_socket_use:nn{luamplib/figure/bbox}\mplibscratchbox
-    \unhbox\mplibscratchbox
-    \tag_socket_use:n{luamplib/figure/end}
+    \tag_socket_use:nnn{luamplib/figure/end}{\mplibscratchbox}{\unhbox\mplibscratchbox}
   \egroup
   \endgroup
 }

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -178,7 +178,7 @@ See source file '\inFileName' for licencing and contact information.
 % The resulting \metapost figures are put in a \TeX\ |hbox| with dimensions
 % adjusted to the \metapost code.
 %
-% The code of luamplib is basically from the |luatex-mplib.lua| and |luatex-mplib.tex| files
+% The code of \pkg{luamplib} is basically from the |luatex-mplib.lua| and |luatex-mplib.tex| files
 % from \ConTeXt. They have been adapted to \LaTeX\ and Plain by Elie Roux and
 % Philipp Gesang and new functionalities have been added by Kim Dohyun.
 % The most notable changes are:
@@ -259,7 +259,7 @@ See source file '\inFileName' for licencing and contact information.
 % \item[shading]
 %   (|texdoc metafun| \S\,8.3) One thing worth mentioning about shading is:
 %   when a color expression is given in string type,
-%   it is regarded by luamplib as
+%   it is regarded by \pkg{luamplib} as
 %   a color expression of \TeX\ side.
 %   For instance, when |withshadecolors("orange", 2/3red)| is given, the first color |"orange"| will be
 %   interpreted as a \pkg{color}, \pkg{xcolor} or \pkg{l3color}'s expression.
@@ -362,7 +362,7 @@ See source file '\inFileName' for licencing and contact information.
 %   |label(textext "my text", origin)|.
 %
 %   \textsc{n.b.} In the background,
-%   luamplib redefines |infont| operator so that the right side
+%   \pkg{luamplib} redefines |infont| operator so that the right side
 %   argument (the font part) is totally ignored. Therefore the left side arguemnt (the text part)
 %   will be typeset with the current \TeX\ font.
 %
@@ -385,7 +385,7 @@ See source file '\inFileName' for licencing and contact information.
 %   affected by previous code chunks.
 %
 % \subsubsection{Separate \metapost instances}
-%   luamplib v2.22 has added the support for several named \metapost instances
+%   \pkg{luamplib} v2.22 has added the support for several named \metapost instances
 %   in \LaTeX{} |mplibcode| environment.
 %   Plain \TeX\ users also can use this functionality.
 %   The syntax for \LaTeX\ is:
@@ -511,11 +511,11 @@ See source file '\inFileName' for licencing and contact information.
 %   prevent code inheritance if \cs{mplibcodeinherit\{true\}} is not declared.
 %
 % \subsubsection{About cache files}
-%   To support |btex ... etex| in external |.mp| files, luamplib
+%   To support |btex ... etex| in external |.mp| files, \pkg{luamplib}
 %   inspects the content of each and every |.mp| file and makes caches
 %   if nececcsary, before returning their paths to \LuaTeX's \mplib library.
 %   This could waste the compilation time, as most |.mp| files
-%   do not contain |btex ... etex| commands.  So luamplib provides
+%   do not contain |btex ... etex| commands.  So \pkg{luamplib} provides
 %   macros as follows, so that users can give instructions about files
 %   that do not require this functionality.
 %   \begin{itemize}
@@ -548,7 +548,7 @@ See source file '\inFileName' for licencing and contact information.
 %   without the unit |bp|.
 %
 % \subsubsection{luamplib.cfg}
-%   At the end of package loading, luamplib searches
+%   At the end of package loading, \pkg{luamplib} searches
 %   |luamplib.cfg| and, if found, reads the file in automatically.
 %   Frequently used settings such as \cs{everymplib}, \cs{mplibforcehmode}
 %   or \cs{mplibcodeinherit} are suitable for going into this file.
@@ -557,9 +557,7 @@ See source file '\inFileName' for licencing and contact information.
 %   \hypertarget{taggedPDF}{}\relax
 % When \pkg{tagpdf} package is loaded and activated, |mplibcode| environment accepts additional options for tagged PDF\@.
 % The code related to this functionality is currently in experimental stage, not guaranteeing backward compatibility.
-% Similar to the \LaTeX's |picture| environment,
-% available optional keys are |alt|, |actualtext|, |artifact|, |text|, |off|, |tag|, |adjust-BBox|,
-% and |tagging-setup|.
+% Available optional keys are similar to those of the \LaTeX's |picture| environment
 % (|texdoc| |latex-lab-graphic|).
 % \begin{description}
 % \item[\texttt{alt=}\meta{text}] starts a |Figure| tag by default and
@@ -567,10 +565,10 @@ See source file '\inFileName' for licencing and contact information.
 %   BBox info will be added automatically to the PDF\@.
 %   This key is needed for ordinary \metapost figures, for which,
 %   if no |alt| text is given, a default text will be used with a warning issued.
-%   You can change alternate text within \metapost code as well:
+%   You can change the alternate text within \metapost code as well:
 %   |VerbatimTeX| |"\mplibalttext|\marg{text}|";|
-% \item[\texttt{actualtext=}\meta{text}] starts a |Span| tag implicitly and sets an actual text
-%   (that is replacement text) from the \meta{text}.\footnote{\relax
+% \item[\texttt{actualtext=}\meta{text}] starts a |Span| tag implicitly and sets a
+%   replacement text (a.k.a. actual text) from the \meta{text}.\footnote{\relax
 %     It is not recommended to personally redefine \cs{prependtomplibbox}.
 %     Apart from using \cs{mplibforcehmode} or \cs{mplibnoforcehmode},
 %     the redefinition might be incompatible with |actualtext| key.
@@ -578,26 +576,30 @@ See source file '\inFileName' for licencing and contact information.
 %   BBox info will not be added.
 %   This key is intended for figures which can be represented by a character or
 %   a small sequence of characters.
-%   You can change actual text within \metapost code as well:
+%   You can change the actual text within \metapost code as well:
 %   |VerbatimTeX| |"\mplibactualtext|\marg{text}|";|
 % \item[\texttt{artifact}] starts an |artifact| MC (marked content).
 %   BBox info will not be added.
 %   This key is intended for decorative figures which have no semantic meaning.
 % \item[\texttt{text}] starts an |artifact| MC but enables tagging on tex-text boxes
 %   (such as |btex| |...| |etex|, excluding pictures made by |infont| operator).\footnote{\relax
-%     |text| key also shares the limitation mentioned in the previous footnote.}
+%     The |text| key also shares the limitation mentioned in the previous footnote.}
 %   BBox info will not be added.
 %   This key is intended for figures whose meaning is the sequence of texts in the
 %   tex-text boxes in the order they are drawn in the figure.
 %   Inside |text|-mode figures, reusing tex-text boxes is strongly discouraged.
-% \item[\texttt{off}] Unlike the same key of |picture| environment, tagging is deactivated by this option.
-%   It is another but simpler way to declare the option |tag=false|.
+% \item[\texttt{off}] Given this key, \pkg{luamplib} does nothing about tagging.
 %   It is up to you to embrace the \metapost figure by proper tagging commands.
 % \item[\texttt{tag=}\meta{name}] You can choose a tag name, default value being |Figure|.
 %   For instance, you can set `|tag=Formula,| |alt=|\meta{text}' to get
 %   a |Formula| structure with its alternate text.\footnote{Beware that this bypasses
 %     \LaTeX's regular math formula tagging.}
-%   However, when the value is |false|, it is a synonym of the |off| option just mentioned.
+%   However, when the value is |false|, tagging is deactivated for the figure.\footnote{\relax
+%     In horizontal mode, the figure will be tagged as a |text| (same as |P|) element
+%     even with |tag=false| option.
+%     Upon this option, therefore, \cs{mplibnoforcehmode}
+%     (see \hyperlink{mplibforcehmode}{above} on this command) is forced internally.
+%     Again, users should not change horizontal/vertical mode by |verbatimtex| command.}
 % \item[\texttt{adjust-BBox=}\meta{dimens}] You can correct the BBox attribute of the figure
 %   by space-separated four dimensional values, which will be added to the
 %   automatically calculated BBox values.
@@ -620,7 +622,7 @@ See source file '\inFileName' for licencing and contact information.
 %     \usemplibgroup[alt=drawing of a triangle]{...}
 %
 %     \mppattern{...}           % see below
-%       \mpfig[off]             % do not tag this figure
+%       \mpfig[tag=false]       % do not tag this figure
 %       ...
 %       \endmpfig
 %     \endmppattern
@@ -635,8 +637,8 @@ See source file '\inFileName' for licencing and contact information.
 % \subsubsection{\texttt{mplibdimen ...}, \texttt{mplibcolor ...}}
 %   These are \metapost interfaces for the \TeX\ commands
 %   \cs{mpdim} and \cs{mpcolor} (see \hyperlink{mpdim}{above} \S\,1.1). For example,
-%   |mplibdimen "\linewidth"| is basically the same as \cs{mpdim\{\cs{linewidth}\}}, and
-%   |mplibcolor "red!50"| is basically the same as \cs{mpcolor\{red!50\}}.
+%   |mplibdimen|\,|"\linewidth"| is basically the same as \cs{mpdim\{\cs{linewidth}\}}, and
+%   |mplibcolor|\,|"red!50"| is basically the same as \cs{mpcolor\{red!50\}}.
 %   The difference is that these \metapost operators can also be used in external |.mp| files,
 %   which cannot have \TeX\ commands outside of the |btex| or |verbatimtex| |...| |etex|.
 %
@@ -719,7 +721,7 @@ See source file '\inFileName' for licencing and contact information.
 %
 %   \leavevmode\llap{\textcolor{red}{☞}\kern1.2\parindent}\relax
 %   To apply the nonzero winding number rule to a picture containing paths,
-%   luamplib appends |withpostscript| |"collect"|
+%   \pkg{luamplib} appends |withpostscript| |"collect"|
 %   to the paths except the last one in the picture.
 %   If you want the even-odd rule instead, you can, with \emph{plain} format as well,
 %   additionally declare |withpostscript| |"evenodd"| to the last path in the picture.
@@ -728,7 +730,7 @@ See source file '\inFileName' for licencing and contact information.
 %   \hypertarget{mpliboutlinetext}{}\relax
 %   From v2.31, a new \metapost operator |mpliboutlinetext| is available, which mimicks
 %   \emph{metafun}'s |outlinetext|. So the syntax is the same: see the \emph{metafun}
-%   manual \S\,8.7 (|texdoc metafun|). A simple example:
+%   manual \S\,8.7 (|texdoc| |metafun|). A simple example:
 %\begin{verbatim}
 %     draw mpliboutlinetext.b ("$\sqrt{2+\alpha}$")
 %         (withcolor \mpcolor{red!50})
@@ -823,7 +825,7 @@ See source file '\inFileName' for licencing and contact information.
 %
 %   When you use special effects such as transparency in a pattern,
 %   |resources| option is needed: for instance, |resources="/ExtGState 1 0 R"|.
-%   However, as luamplib automatically includes the resources of the current page, this option
+%   However, as \pkg{luamplib} automatically includes the resources of the current page, this option
 %   is not needed in most cases.
 %
 %   Option |colored=false| (|coloured| is a synonym of |colored|) will generate an uncolored pattern which shall have no color at all.
@@ -933,7 +935,7 @@ See source file '\inFileName' for licencing and contact information.
 % to produce a single object, so that outer transparency effect, if any,
 % will be applied to the group as a whole, not to the individual objects cumulatively.
 %
-% The additional feature provided by luamplib is that
+% The additional feature provided by \pkg{luamplib} is that
 % you can reuse the group as many times as you want
 % in the \TeX{} code or in other \metapost code chunks,
 % with infinitesimal increase in the size of PDF file.
@@ -1073,9 +1075,9 @@ See source file '\inFileName' for licencing and contact information.
 %   \hypertarget{luamplibshading}{}\relax
 %   The syntax is exactly the same as \emph{metafun}'s new shading method (|texdoc metafun| \S\,8.3.3), except that
 %   the `|shade|' contained in each and every macro name has changed to
-%   `|shading|' in luamplib: for instance, while |withshademethod| is
+%   `|shading|' in \pkg{luamplib}: for instance, while |withshademethod| is
 %   a macro name which only works with \emph{metafun} format,
-%   the equivalent provided by luamplib, |withshadingmethod|, works with \emph{plain} as well.
+%   the equivalent provided by \pkg{luamplib}, |withshadingmethod|, works with \emph{plain} as well.
 %   Other differences to the \emph{metafun}'s and some cautions are:
 %   \begin{itemize}
 %   \item \emph{textual pictures} (pictures made by |btex| |...| |etex|, |textext|,
@@ -1088,9 +1090,9 @@ See source file '\inFileName' for licencing and contact information.
 %\end{verbatim}
 %   \item When you give shading effect to a picture made by `|infont|' operator,
 %     the result of |withshadingvector| will be the same as that of |withshadingdirection|,
-%     as luamplib considers only the bounding box of the picture.
+%     as \pkg{luamplib} considers only the bounding box of the picture.
 %   \end{itemize}
-% Macros provided by luamplib are:
+% Macros provided by \pkg{luamplib} are:
 % \begin{description}
 %   \let\bfseries\relax
 %   \item[\meta{path}\,\textbar\,\meta{textual picture} \texttt{withshadingmethod} \meta{string}]
@@ -1166,14 +1168,14 @@ See source file '\inFileName' for licencing and contact information.
 %   Using the primitive |runscript| \meta{string}, you can run a Lua code chunk from \metapost side
 %   and get some \metapost code returned by Lua if you want.
 %   As the functionality is provided by the \mplib library itself,
-%   luamplib does not have much to say about it.
+%   \pkg{luamplib} does not have much to say about it.
 %
 %   One thing is worth mentioning, however:
 %   if you return a Lua \emph{table} to the \metapost process,
 %   it is automatically converted to a relevant \metapost value type
 %   such as pair, color, cmykcolor or transform.
 %   So users can save some extra toil of converting a table to a string, though it's not a big deal.
-%   For instance, |runscript "return {1,0,0}"| will give you the \metapost color expression |(1,0,0)|
+%   For instance, |runscript|\,|"return {1,0,0}"| will give you the \metapost color expression |(1,0,0)|
 %   automatically.
 %
 % \subsubsection{Lua table \texttt{luamplib.instances}}
@@ -5224,7 +5226,6 @@ end
 \tl_new:N \l__luamplib_tag_struct_tl
 \tl_set:Nn\l__luamplib_tag_struct_tl {Figure}
 \bool_new:N \l__luamplib_tag_usetext_bool
-\bool_new:N \l__luamplib_tag_was_active_bool
 \bool_new:N \l__luamplib_tag_bboxcorr_bool
 \seq_new:N  \l__luamplib_tag_bboxcorr_seq
 \tl_new:N \l__luamplib_tag_bbox_draw_tl
@@ -5254,6 +5255,9 @@ end
     \tag_mc_end_push:
     \tag_struct_begin:n{tag=NonStruct,stash}
     \cs_gset_nopar:cpe {luamplib.tagbox.#1} {\tag_get:n{struct_num}}
+%    \end{macrocode}
+% TODO: We force a structure. If not, |a| and |b| in |btex a $x$ b etex| are not tagged.
+%    \begin{macrocode}
     \tag_mc_begin:n{tag=text}
 }
 \socket_new_plug:nnn{tagsupport/luamplib/textext/end}{default}
@@ -5297,8 +5301,30 @@ end
 \socket_assign_plug:nn{tagsupport/luamplib/textext/begin}{default}
 \socket_assign_plug:nn{tagsupport/luamplib/textext/end}{default}
 \socket_assign_plug:nn{tagsupport/luamplib/textext/put}{default}
-\cs_set_nopar:Npn \luamplibtagtextbegin #1 { \tag_socket_use:nn{luamplib/textext/begin}{#1} }
-\cs_set_nopar:Npn \luamplibtagtextend { \tag_socket_use:n{luamplib/textext/end} }
+\cs_set_nopar:Npn \luamplibtagtextbegin #1
+{
+  \bool_if:NTF \l__luamplib_tag_usetext_bool
+  {
+    \tag_socket_use:nn{luamplib/textext/begin}{#1}
+  }
+  {
+    \tag_if_active:TF
+      { \bool_set_true:N \l_tmpa_bool }
+      { \bool_set_false:N \l_tmpa_bool }
+    \tag_suspend:n{\luamplibtagtextbegin}
+  }
+}
+\cs_set_nopar:Npn \luamplibtagtextend
+{
+  \bool_if:NTF \l__luamplib_tag_usetext_bool
+  {
+    \tag_socket_use:n{luamplib/textext/end}
+  }
+  {
+    \bool_if:NT \l_tmpa_bool
+      { \tag_resume:n{\luamplibtagtextend} }
+  }
+}
 \cs_set_nopar:Npn \mplibputtextbox #1
 {
   \vbox to 0pt{\vss\hbox to 0pt{%
@@ -5310,7 +5336,6 @@ end
 }
 %    \end{macrocode}
 % TODO: Not sure whether asgroup will be tagged correctly.
-%
 %\begin{verbatim}
 %    \cs_set_nopar:Npn \luamplibtagasgroupbegin
 %    {
@@ -5331,7 +5356,6 @@ end
 %      }
 %    }
 %\end{verbatim}
-%
 % Sockets for mplibgroup
 %    \begin{macrocode}
 \socket_new:nn{tagsupport/luamplib/mplibgroup/begin}{0}
@@ -5355,7 +5379,7 @@ end
 \socket_assign_plug:nn{tagsupport/luamplib/mplibgroup/begin}{default}
 \socket_assign_plug:nn{tagsupport/luamplib/mplibgroup/end}{default}
 %    \end{macrocode}
-% Sockets for environment options
+% Sockets for main process
 %    \begin{macrocode}
 \socket_new:nn{tagsupport/luamplib/begin}{0}
 \socket_new:nn{tagsupport/luamplib/end}{0}
@@ -5514,10 +5538,11 @@ end
       }
 }
 %    \end{macrocode}
-% horizontal mode upon |text|, |actualtext|, and |off|
+% horizontal mode upon |text| and |actualtext|
 %    \begin{macrocode}
 \cs_set_nopar:Npn \__luamplib_tag_pseudo_para_begin:
 {
+  \prependtomplibbox \mplibnoforcehmode
   \mode_if_vertical:T
   {
     \tag_socket_use:n{para/begin}
@@ -5537,32 +5562,25 @@ end
 \socket_new:nn{tagsupport/luamplib/init}{0}
 \socket_new_plug:nnn{tagsupport/luamplib/init}{alt}
 {
-  \bool_set_true:N \l__luamplib_tag_was_active_bool
   \socket_assign_plug:nn{tagsupport/luamplib/begin}{alt}
   \socket_assign_plug:nn{tagsupport/luamplib/end}{alt}
   \socket_assign_plug:nn{tagsupport/luamplib/bbox}{alt}
-  \tag_suspend:n{luamplib/init}
 }
 \socket_new_plug:nnn{tagsupport/luamplib/init}{actualtext}
 {
-  \bool_set_true:N \l__luamplib_tag_was_active_bool
   \socket_assign_plug:nn{tagsupport/luamplib/begin}{actualtext}
   \socket_assign_plug:nn{tagsupport/luamplib/end}{actualtext}
   \socket_assign_plug:nn{tagsupport/luamplib/bbox}{noop}
   \__luamplib_tag_pseudo_para_begin:
-  \tag_suspend:n{luamplib/init}
 }
 \socket_new_plug:nnn{tagsupport/luamplib/init}{artifact}
 {
-  \bool_set_true:N \l__luamplib_tag_was_active_bool
   \socket_assign_plug:nn{tagsupport/luamplib/begin}{artifact}
   \socket_assign_plug:nn{tagsupport/luamplib/end}{artifact}
   \socket_assign_plug:nn{tagsupport/luamplib/bbox}{noop}
-  \tag_suspend:n{luamplib/init}
 }
 \socket_new_plug:nnn{tagsupport/luamplib/init}{text}
 {
-  \bool_set_true:N \l__luamplib_tag_was_active_bool
   \bool_set_true:N \l__luamplib_tag_usetext_bool
   \socket_assign_plug:nn{tagsupport/luamplib/begin}{artifact}
   \socket_assign_plug:nn{tagsupport/luamplib/end}{artifact}
@@ -5571,8 +5589,17 @@ end
 }
 \socket_new_plug:nnn{tagsupport/luamplib/init}{off}
 {
-  \bool_set_false:N \l__luamplib_tag_was_active_bool
-  \tag_suspend:n{luamplib/init}
+  \socket_assign_plug:nn{tagsupport/luamplib/begin}{noop}
+  \socket_assign_plug:nn{tagsupport/luamplib/end}{noop}
+  \socket_assign_plug:nn{tagsupport/luamplib/bbox}{noop}
+}
+\socket_new_plug:nnn{tagsupport/luamplib/init}{false}
+{
+%    \end{macrocode}
+% As we deactivate tagging, switching to horizontal mode raises an error.
+%    \begin{macrocode}
+  \mplibnoforcehmode
+  \tag_suspend:n{luamplib/tag/false}
 }
 \socket_assign_plug:nn{tagsupport/luamplib/init}{alt}
 %    \end{macrocode}
@@ -5590,23 +5617,14 @@ end
         \tl_set:Ne\l__luamplib_tag_actual_tl{\text_purify:n{#1}}
         \socket_assign_plug:nn{tagsupport/luamplib/init}{actualtext}
       }
-    ,artifact .code:n =
-      {
-        \socket_assign_plug:nn{tagsupport/luamplib/init}{artifact}
-      }
-    ,text .code:n =
-      {
-        \socket_assign_plug:nn{tagsupport/luamplib/init}{text}
-      }
-    ,off .code:n =
-      {
-        \socket_assign_plug:nn{tagsupport/luamplib/init}{off}
-      }
-    ,tag .code:n =
+    ,artifact .code:n = { \socket_assign_plug:nn{tagsupport/luamplib/init}{artifact} }
+    ,text     .code:n = { \socket_assign_plug:nn{tagsupport/luamplib/init}{text} }
+    ,off      .code:n = { \socket_assign_plug:nn{tagsupport/luamplib/init}{off} }
+    ,tag      .code:n =
       {
         \str_case:nnF {#1}
           {
-            {false}    { \keys_set:nn {luamplib/tag} {off} }
+            {false}    { \socket_assign_plug:nn{tagsupport/luamplib/init}{false} }
             {text}     { \keys_set:nn {luamplib/tag} {text} }
             {artifact} { \keys_set:nn {luamplib/tag} {artifact} }
           }
@@ -5619,24 +5637,21 @@ end
         \bool_set_true:N \l__luamplib_tag_bboxcorr_bool
         \seq_set_split:Nnn \l__luamplib_tag_bboxcorr_seq{~}{#1~0pt~0pt~0pt~0pt}
       }
-    ,tagging-setup .code:n =
-      {
-        \keys_set_known:nn {luamplib/tag} {#1}
-      }
+    ,tagging-setup .code:n = { \keys_set_known:nn {luamplib/tag} {#1} }
   }
 \keys_define:nn {luamplib/instance}
   {
-    ,instance .code:n = { \tl_gset:Nn \currentmpinstancename {#1} }
+    ,instance     .code:n = { \tl_gset:Nn \currentmpinstancename {#1} }
     ,instancename .meta:n = { instance = {#1} }
-    ,unknown .code:n = { \tl_gset:Ne \currentmpinstancename {\l_keys_key_str} }
+    ,unknown      .code:n = { \tl_gset:Ne \currentmpinstancename {\l_keys_key_str} }
   }
 %    \end{macrocode}
 % Redefine our macros
 %    \begin{macrocode}
 \cs_set_nopar:Npn \mplibstarttoPDF #1 #2 #3 #4
   {
-    \hbox dir TLT\bgroup
-    \bool_if:NT \l__luamplib_tag_was_active_bool { \tag_resume:n{\mplibstarttoPDF} }
+    \prependtomplibbox
+    \hbox dir~TLT\bgroup
     \tag_socket_use:n{luamplib/begin}
     \xdef\MPllx{#1}\xdef\MPlly{#2}%
     \xdef\MPurx{#3}\xdef\MPury{#4}%
@@ -5680,7 +5695,6 @@ end
     \keys_set:nV {luamplib/instance} \l_tmpa_tl
     \tl_if_empty:NF \currentmpinstancename
       { \tl_set:Nn\l__luamplib_tag_alt_dflt_tl {metapost~figure~\currentmpinstancename} }
-    \prependtomplibbox
     \tag_socket_use:n{luamplib/init}
     \mplibtmptoks{}\ltxdomplibcode
   }
@@ -5692,7 +5706,6 @@ end
     \keys_set:nV {luamplib/instance} \l_tmpa_tl
     \tl_if_empty:NF \mpfiginstancename
       { \tl_set:Nn\l__luamplib_tag_alt_dflt_tl {metapost~figure~\mpfiginstancename} }
-    \prependtomplibbox
     \tag_socket_use:n{luamplib/init}
     \IfBooleanTF{#1}
       { \mplibprempfig * }
@@ -5705,10 +5718,8 @@ end
     \keys_set_known:neN {luamplib/tag} {#1} \l_tmpa_tl
     \keys_set:nV {luamplib/instance} \l_tmpa_tl
     \tl_set:Nn\l__luamplib_tag_alt_dflt_tl {metapost~figure~#2}
-    \prependtomplibbox
     \tag_socket_use:n{luamplib/init}
-    \hbox dir TLT\bgroup
-    \bool_if:NT \l__luamplib_tag_was_active_bool { \tag_resume:n{\usemplibgroup} }
+    \prependtomplibbox\hbox dir~TLT\bgroup
     \tag_socket_use:n{luamplib/begin}
     \setbox\mplibscratchbox\hbox\bgroup
     \tag_socket_use:n{luamplib/mplibgroup/begin}

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -5249,12 +5249,14 @@ end
     \tag_struct_begin:n{tag=NonStruct,stash}
     \cs_gset_nopar:cpe {luamplib.tagbox.#1} {\tag_get:n{struct_num}}
 %    \end{macrocode}
-% TODO: We force a structure. If not, |a| and |b| in |btex a $x$ b etex| are not tagged.
+% TODO: We force an MC. If not, |a| and |b| in |btex a $x$ b etex| are not tagged.
 %    \begin{macrocode}
     \tag_mc_begin:n{}
+    \tag_tool:n{para/tagging=false}
 }
 \socket_new_plug:nnn{tagsupport/luamplib/textext/end}{default}
 {
+    \tag_tool:n{para/tagging=true}
     \tag_mc_end:
     \tag_struct_end:
     \tag_mc_begin_pop:n{}
@@ -5288,7 +5290,8 @@ end
 {
 %    \end{macrocode}
 % TODO: we test |text| mode here.
-% If the socket is used for all modes, we can get a lot of structure-has-no-parent warning.
+% If the socket is used for all modes, we will get a lot of structure-has-no-parent warning;
+% no good-looking, though it seems to be no harm.
 %    \begin{macrocode}
   \bool_if:NTF \l__luamplib_tag_usetext_bool
   {
@@ -5580,10 +5583,6 @@ end
   \socket_assign_plug:nn{tagsupport/luamplib/figure/end}{artifact}
   \socket_assign_plug:nn{tagsupport/luamplib/figure/bbox}{noop}
   \__luamplib_tag_pseudo_para_begin:
-%    \end{macrocode}
-% TODO: To avoid nested |P|. Not sure this is a bug of tagpdf.
-%    \begin{macrocode}
-  \cs_set_nopar:Npn \prependtomplibbox {\tag_struct_begin:n{tag=NonStruct,stash} \tag_struct_end:}
 }
 \socket_new_plug:nnn{tagsupport/luamplib/figure/init}{off}
 {

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -558,7 +558,7 @@ See source file '\inFileName' for licencing and contact information.
 % When \pkg{tagpdf} package is loaded and activated, |mplibcode| environment accepts additional options for tagged PDF\@.
 % The code related to this functionality is currently in experimental stage, not guaranteeing backward compatibility.
 % Similar to the \LaTeX's |picture| environment,
-% available optional keys are |alt|, |actualtext|, |artifact|, |text|, |off|, |tag|, |correct-BBox|,
+% available optional keys are |alt|, |actualtext|, |artifact|, |text|, |off|, |tag|, |adjust-BBox|,
 % and |tagging-setup|.
 % (|texdoc| |latex-lab-graphic|).
 % \begin{description}
@@ -570,16 +570,12 @@ See source file '\inFileName' for licencing and contact information.
 %   You can change alternate text within \metapost code as well:
 %   |VerbatimTeX| |"\mplibalttext|\marg{text}|";|
 % \item[\texttt{actualtext=}\meta{text}] starts a |Span| tag implicitly and sets an actual text
-%   (that is replacement text) from the \meta{text}.
-%   BBox info will not be added.
-%   Horizontal mode is forced by \cs{noindent} or \cs{leavevmode} command
-%   according to the definition of \cs{prependtomplibbox}.\footnote{\relax
-%     But the vertical mode will be restored after the mplibcode environment,
-%     if it is started in a vertical mode.
-%     Anyway, it is not recommended to personally redefine \cs{prependtomplibbox}.
+%   (that is replacement text) from the \meta{text}.\footnote{\relax
+%     It is not recommended to personally redefine \cs{prependtomplibbox}.
 %     Apart from using \cs{mplibforcehmode} or \cs{mplibnoforcehmode},
 %     the redefinition might be incompatible with |actualtext| key.
 %     See \hyperlink{mplibforcehmode}{above} on these commands. }
+%   BBox info will not be added.
 %   This key is intended for figures which can be represented by a character or
 %   a small sequence of characters.
 %   You can change actual text within \metapost code as well:
@@ -588,31 +584,25 @@ See source file '\inFileName' for licencing and contact information.
 %   BBox info will not be added.
 %   This key is intended for decorative figures which have no semantic meaning.
 % \item[\texttt{text}] starts an |artifact| MC but enables tagging on tex-text boxes
-%   (such as |btex| |...| |etex|, excluding pictures made by |infont| operator).
-%   BBox info will not be added.
-%   Horizontal mode is forced by \cs{noindent} or \cs{leavevmode} command
-%   according to the definition of \cs{prependtomplibbox}.\footnote{\relax
+%   (such as |btex| |...| |etex|, excluding pictures made by |infont| operator).\footnote{\relax
 %     |text| key also shares the limitation mentioned in the previous footnote.}
+%   BBox info will not be added.
 %   This key is intended for figures whose meaning is the sequence of texts in the
 %   tex-text boxes in the order they are drawn in the figure.
 %   Inside |text|-mode figures, reusing tex-text boxes is strongly discouraged.
 % \item[\texttt{off}] Unlike the same key of |picture| environment, tagging is deactivated by this option.
 %   It is another but simpler way to declare the option |tag=false|.
-%   Horizontal mode is forced by \cs{noindent} or \cs{leavevmode} command
-%   according to the definition of \cs{prependtomplibbox}.\footnote{\relax
-%     |off| key also shares the limitation mentioned in the previous footnote.}
 %   It is up to you to embrace the \metapost figure by proper tagging commands.
 % \item[\texttt{tag=}\meta{name}] You can choose a tag name, default value being |Figure|.
 %   For instance, you can set `|tag=Formula,| |alt=|\meta{text}' to get
-%   a |Formula| structure with its alternate text.\footnote{But now the |text| key
-%     with \pkg{unicode-math} package loaded seems to be better than |tag=Formula| option.}
+%   a |Formula| structure with its alternate text.\footnote{Beware that this bypasses
+%     \LaTeX's regular math formula tagging.}
 %   However, when the value is |false|, it is a synonym of the |off| option just mentioned.
-% \item[\texttt{correct-BBox=}\meta{dimens}] You can correct the BBox attribute of the figure
+% \item[\texttt{adjust-BBox=}\meta{dimens}] You can correct the BBox attribute of the figure
 %   by space-separated four dimensional values, which will be added to the
-%   automatically-calculated BBox values.
-%   To draw the bounding box for checking with half-transparent red color, you can declare
-%   |\DocumentMetadata|\allowbreak|{debug=|\allowbreak|BBox}| after the setup
-%   |\DocumentMetadata|\allowbreak|{tagging=|\allowbreak|on}| is completed.
+%   automatically calculated BBox values.
+%   To draw the bounding box for checking with half transparent red color, you can add
+%   |debug=|\allowbreak|BBox| to the argument of \cs{DocumentMetadata} command.
 % \item[\texttt{tagging-setup=}\meta{key-val list}]
 %   This key accepts as its value the list of key-value options mentioned so far.
 % \end{description}
@@ -1063,7 +1053,7 @@ See source file '\inFileName' for licencing and contact information.
 % using the \TeX\ command \cs{usemplibgroup} or
 % the \metapost command |usemplibgroup|.
 % The behavior of these commands is the same as that described \hyperlink{usemplibgroup}{above},
-% excepting that mplibgroup made by \TeX\ code (not by \metapost code) respects original height and depth.
+% excepting that the mplibgroup made by \TeX\ code (not by \metapost code) respects original height and depth.
 %
 % \subsubsection{\texttt{... withtransparency ...}}
 %   \hypertarget{luamplibtransparency}{}\relax
@@ -5208,7 +5198,7 @@ end
       ,text         .code:n = { }
       ,off          .code:n = { }
       ,tag          .code:n = { }
-      ,correct-BBox .code:n = { }
+      ,adjust-BBox  .code:n = { }
       ,tagging-setup .code:n = { }
       ,instance     .code:n = { \tl_gset:Nn \currentmpinstancename {#1} }
       ,instancename .meta:n = { instance = {#1} }
@@ -5234,9 +5224,9 @@ end
 \tl_new:N \l__luamplib_tag_struct_tl
 \tl_set:Nn\l__luamplib_tag_struct_tl {Figure}
 \bool_new:N \l__luamplib_tag_usetext_bool
-\bool_new:N \g__luamplib_tag_asgroup_bool
-\bool_new:N\l__luamplib_tag_bboxcorr_bool
-\seq_new:N\l__luamplib_tag_bboxcorr_seq
+\bool_new:N \l__luamplib_tag_was_active_bool
+\bool_new:N \l__luamplib_tag_bboxcorr_bool
+\seq_new:N  \l__luamplib_tag_bboxcorr_seq
 \tl_new:N \l__luamplib_tag_bbox_draw_tl
 \tl_new:N \l__luamplib_BBox_label_tl
 \tl_new:N \l__luamplib_BBox_llx_tl
@@ -5262,90 +5252,53 @@ end
 \socket_new_plug:nnn{tagsupport/luamplib/textext/begin}{default}
 {
     \tag_mc_end_push:
-    \tag_mc_begin:n{}
     \tag_struct_begin:n{tag=NonStruct,stash}
-    \def\myboxnum{#1}
-    \edef\mystructnum{\tag_get:n{struct_num}}
-    \edef\statebeforebox{\inteval{\tag_get:n{struct_counter}+\tag_get:n{mc_counter}}}
+    \cs_gset_nopar:cpe {luamplib.tagbox.#1} {\tag_get:n{struct_num}}
+    \tag_mc_begin:n{tag=text}
 }
 \socket_new_plug:nnn{tagsupport/luamplib/textext/end}{default}
 {
-    \edef\stateafterbox{\inteval{\tag_get:n{struct_counter}+\tag_get:n{mc_counter}}}
-    \int_compare:nNnTF
-      {\stateafterbox}
-      =
-      {\statebeforebox}
-      { \cs_gset_nopar:cpe {luamplib.notagbox.\myboxnum} {\mystructnum} }
-      { \cs_gset_nopar:cpe {luamplib.tagbox.\myboxnum} {\mystructnum} }
-    \tag_struct_end:
     \tag_mc_end:
+    \tag_struct_end:
     \tag_mc_begin_pop:n{}
 }
 \socket_new_plug:nnn{tagsupport/luamplib/textext/put}{default}
 {
-    \bool_if:NTF \l__luamplib_tag_usetext_bool
+  \bool_if:NTF \l__luamplib_tag_usetext_bool
+  {
+    \tag_resume:n{\mplibputtextbox}
+    \tag_mc_end:
+    \cs_if_exist:cTF {luamplib.tagbox.#1}
     {
-      \tag_resume:n{\mplibputtextbox}
-      \tag_mc_end:
-      \cs_if_exist:cTF {luamplib.tagbox.#1}
-      {
-        \bool_gset_false:N \g__luamplib_tag_asgroup_bool
 %    \end{macrocode}
 % TODO: To avoid nested |P|. Not sure this is a bug of tagpdf.
 %    \begin{macrocode}
-\tag_struct_begin:n{tag=NonStruct}
-        \tag_struct_use_num:n {\csname luamplib.tagbox.#1\endcsname}
-        #2
-\tag_struct_end:
-      }
-      {
-        \bool_gset_true:N \g__luamplib_tag_asgroup_bool
-        \cs_if_exist:cF {luamplib.notagbox.#1}
-        {
-          \msg_warning:nnn{luamplib}{figure-text-reuse}{#1}
-        }
-        \tag_mc_begin:n{}
-        \int_set:Nn \l_tmpa_int {#1}
-        \tag_mc_reset_box:N \l_tmpa_int
-        #2
-        \tag_mc_end:
-      }
-      \tag_mc_begin:n{artifact}
+      \tag_struct_begin:n{tag=NonStruct}
+      \tag_struct_use_num:n {\csname luamplib.tagbox.#1\endcsname}
+      #2
+      \tag_struct_end:
     }
     {
-      \bool_gset_false:N \g__luamplib_tag_asgroup_bool
+      \msg_warning:nnn{luamplib}{figure-text-reuse}{#1}
+      \tag_mc_begin:n{}
       \int_set:Nn \l_tmpa_int {#1}
       \tag_mc_reset_box:N \l_tmpa_int
       #2
+      \tag_mc_end:
     }
+    \tag_mc_begin:n{artifact}
+  }
+  {
+    \int_set:Nn \l_tmpa_int {#1}
+    \tag_mc_reset_box:N \l_tmpa_int
+    #2
+  }
 }
 \socket_assign_plug:nn{tagsupport/luamplib/textext/begin}{default}
 \socket_assign_plug:nn{tagsupport/luamplib/textext/end}{default}
 \socket_assign_plug:nn{tagsupport/luamplib/textext/put}{default}
-\cs_set_nopar:Npn \luamplibtagtextbegin #1
-{
-  \bool_if:NTF \l__luamplib_tag_usetext_bool
-  {
-    \tag_socket_use:nn{luamplib/textext/begin}{#1}
-  }
-  {
-    \tag_if_active:TF
-      { \bool_set_true:N \l_tmpa_bool }
-      { \bool_set_false:N \l_tmpa_bool }
-    \tag_suspend:n{\luamplibtagtextbegin}
-  }
-}
-\cs_set_nopar:Npn \luamplibtagtextend
-{
-  \bool_if:NTF \l__luamplib_tag_usetext_bool
-  {
-    \tag_socket_use:n{luamplib/textext/end}
-  }
-  {
-    \bool_if:NT \l_tmpa_bool
-      { \tag_resume:n{\luamplibtagtextend} }
-  }
-}
+\cs_set_nopar:Npn \luamplibtagtextbegin #1 { \tag_socket_use:nn{luamplib/textext/begin}{#1} }
+\cs_set_nopar:Npn \luamplibtagtextend { \tag_socket_use:n{luamplib/textext/end} }
 \cs_set_nopar:Npn \mplibputtextbox #1
 {
   \vbox to 0pt{\vss\hbox to 0pt{%
@@ -5357,29 +5310,50 @@ end
 }
 %    \end{macrocode}
 % TODO: Not sure whether asgroup will be tagged correctly.
+%
+%\begin{verbatim}
+%    \cs_set_nopar:Npn \luamplibtagasgroupbegin
+%    {
+%      \bool_if:NT \l__luamplib_tag_usetext_bool
+%      {
+%        \tag_resume:n{\luamplibtagasgroupbegin}
+%        \tag_mc_end:
+%        \tag_mc_begin:n{}
+%      }
+%    }
+%    \cs_set_nopar:Npn \luamplibtagasgroupend
+%    {
+%      \bool_if:NT \l__luamplib_tag_usetext_bool
+%      {
+%        \tag_mc_end:
+%        \tag_mc_begin:n{artifact}
+%        \tag_suspend:n{\luamplibtagasgroupend}
+%      }
+%    }
+%\end{verbatim}
+%
+% Sockets for mplibgroup
 %    \begin{macrocode}
-\cs_set_nopar:Npn \luamplibtagasgroupbegin
+\socket_new:nn{tagsupport/luamplib/mplibgroup/begin}{0}
+\socket_new:nn{tagsupport/luamplib/mplibgroup/end}{0}
+\socket_new_plug:nnn{tagsupport/luamplib/mplibgroup/begin}{default}
 {
-  \bool_lazy_and:nnT
-  {\g__luamplib_tag_asgroup_bool}
-  {\l__luamplib_tag_usetext_bool}
-  {
-    \tag_resume:n{\luamplibtagasgroupbegin}
-    \tag_mc_end:
-    \tag_mc_begin:n{}
-  }
+    \bool_if:NT \l__luamplib_tag_usetext_bool
+    {
+      \tag_mc_end:
+      \tag_mc_begin:n{}
+    }
 }
-\cs_set_nopar:Npn \luamplibtagasgroupend
+\socket_new_plug:nnn{tagsupport/luamplib/mplibgroup/end}{default}
 {
-  \bool_lazy_and:nnT
-  {\g__luamplib_tag_asgroup_bool}
-  {\l__luamplib_tag_usetext_bool}
-  {
-    \tag_mc_end:
-    \tag_mc_begin:n{artifact}
-    \tag_suspend:n{\luamplibtagasgroupend}
-  }
+    \bool_if:NT \l__luamplib_tag_usetext_bool
+    {
+      \tag_mc_end:
+      \tag_mc_begin:n{artifact}
+    }
 }
+\socket_assign_plug:nn{tagsupport/luamplib/mplibgroup/begin}{default}
+\socket_assign_plug:nn{tagsupport/luamplib/mplibgroup/end}{default}
 %    \end{macrocode}
 % Sockets for environment options
 %    \begin{macrocode}
@@ -5434,17 +5408,15 @@ end
     \tag_mc_end:
     \tag_mc_begin_pop:n{}
 }
-\socket_assign_plug:nn{tagsupport/luamplib/begin}{alt}
-\socket_assign_plug:nn{tagsupport/luamplib/end}{alt}
 %    \end{macrocode}
 % A socket for BBox attribute
 %    \begin{macrocode}
 \socket_new:nn{tagsupport/luamplib/bbox}{1}
-\socket_new_plug:nnn{tagsupport/luamplib/bbox}{attr}
+\socket_new_plug:nnn{tagsupport/luamplib/bbox}{alt}
 {
     \tl_set:Ne \l__luamplib_BBox_label_tl {luamplib.BBox.\tag_get:n{struct_num}}
     \tex_savepos:D
-    \property_record:ee{\l__luamplib_BBox_label_tl}{xpos,ypos,abspage}
+    \property_record:ee{\l__luamplib_BBox_label_tl}{xpos,ypos}
     \tl_set:Ne \l__luamplib_BBox_llx_tl
       {
         \dim_to_decimal_in_bp:n
@@ -5541,89 +5513,68 @@ end
         }
       }
 }
-\socket_assign_plug:nn{tagsupport/luamplib/bbox}{attr}
 %    \end{macrocode}
-% A sockets to force horizontal mode upon |text|, |actualtext|, and |off|
+% horizontal mode upon |text|, |actualtext|, and |off|
 %    \begin{macrocode}
-\cs_set_nopar:Npn \__luamplib_tag_hmode_force:
+\cs_set_nopar:Npn \__luamplib_tag_pseudo_para_begin:
 {
   \mode_if_vertical:T
   {
-    \cs_if_eq:NNTF \prependtomplibbox \relax
-    {
-      \noindent
-      \aftergroup \par
-    }
-    {
-      \bool_lazy_any:nTF
-      {
-        { \cs_if_eq_p:NN \prependtomplibbox \leavevmode }
-        { \cs_if_eq_p:NN \prependtomplibbox \noindent }
-        { \cs_if_eq_p:NN \prependtomplibbox \mode_leave_vertical: }
-      }
-      { \prependtomplibbox }
-      {
-        \str_set:Ne \l_tmpa_str {\cs_meaning:N \prependtomplibbox}
-        \clist_set:Nn \l_tmpa_clist
-          {\unhbox \voidb@x,\noindent,\mode_leave_vertical:,\tex_indent:D,\indent}
-        \bool_set_false:N \l_tmpa_bool
-        \clist_map_inline:Nn \l_tmpa_clist
-          {
-            \str_if_in:NnT \l_tmpa_str {##1}
-            {
-              ##1
-              \bool_set_true:N \l_tmpa_bool
-              \clist_map_break:
-             }
-          }
-        \bool_if:NF \l_tmpa_bool
-        {
-          \noindent         % prone to error!
-          \aftergroup \par
-        }
-      }
-    }
+    \tag_socket_use:n{para/begin}
+    \group_insert_after:N \__luamplib_tag_pseudo_para_end:
   }
 }
-\socket_new:nn{tagsupport/luamplib/starting}{0}
-\socket_new_plug:nnn{tagsupport/luamplib/starting}{actualtext}
+\cs_set_nopar:Npn \__luamplib_tag_pseudo_para_end:
 {
-  \__luamplib_tag_hmode_force:
+  \mode_if_vertical:T
+  {
+    \tag_socket_use:n{para/end}
+  }
 }
-\socket_new_plug:nnn{tagsupport/luamplib/starting}{text}
-{
-  \bool_set_true:N \l__luamplib_tag_usetext_bool
-  \__luamplib_tag_hmode_force:
-}
-\socket_new_plug:nnn{tagsupport/luamplib/starting}{off}
-{
-  \__luamplib_tag_hmode_force:
-  \tag_suspend:n{luamplib/tag/off}
-}
-\socket_assign_plug:nn{tagsupport/luamplib/starting}{noop}
 %    \end{macrocode}
-% Sockets for mplibgroup
+% A socket for tagging init
 %    \begin{macrocode}
-\socket_new:nn{tagsupport/luamplib/mplibgroup/begin}{0}
-\socket_new:nn{tagsupport/luamplib/mplibgroup/end}{0}
-\socket_new_plug:nnn{tagsupport/luamplib/mplibgroup/begin}{default}
+\socket_new:nn{tagsupport/luamplib/init}{0}
+\socket_new_plug:nnn{tagsupport/luamplib/init}{alt}
 {
-    \bool_if:NT \l__luamplib_tag_usetext_bool
-    {
-      \tag_mc_end:
-      \tag_mc_begin:n{}
-    }
+  \bool_set_true:N \l__luamplib_tag_was_active_bool
+  \socket_assign_plug:nn{tagsupport/luamplib/begin}{alt}
+  \socket_assign_plug:nn{tagsupport/luamplib/end}{alt}
+  \socket_assign_plug:nn{tagsupport/luamplib/bbox}{alt}
+  \tag_suspend:n{luamplib/init}
 }
-\socket_new_plug:nnn{tagsupport/luamplib/mplibgroup/end}{default}
+\socket_new_plug:nnn{tagsupport/luamplib/init}{actualtext}
 {
-    \bool_if:NT \l__luamplib_tag_usetext_bool
-    {
-      \tag_mc_end:
-      \tag_mc_begin:n{artifact}
-    }
+  \bool_set_true:N \l__luamplib_tag_was_active_bool
+  \socket_assign_plug:nn{tagsupport/luamplib/begin}{actualtext}
+  \socket_assign_plug:nn{tagsupport/luamplib/end}{actualtext}
+  \socket_assign_plug:nn{tagsupport/luamplib/bbox}{noop}
+  \__luamplib_tag_pseudo_para_begin:
+  \tag_suspend:n{luamplib/init}
 }
-\socket_assign_plug:nn{tagsupport/luamplib/mplibgroup/begin}{default}
-\socket_assign_plug:nn{tagsupport/luamplib/mplibgroup/end}{default}
+\socket_new_plug:nnn{tagsupport/luamplib/init}{artifact}
+{
+  \bool_set_true:N \l__luamplib_tag_was_active_bool
+  \socket_assign_plug:nn{tagsupport/luamplib/begin}{artifact}
+  \socket_assign_plug:nn{tagsupport/luamplib/end}{artifact}
+  \socket_assign_plug:nn{tagsupport/luamplib/bbox}{noop}
+  \tag_suspend:n{luamplib/init}
+}
+\socket_new_plug:nnn{tagsupport/luamplib/init}{text}
+{
+  \bool_set_true:N \l__luamplib_tag_was_active_bool
+  \bool_set_true:N \l__luamplib_tag_usetext_bool
+  \socket_assign_plug:nn{tagsupport/luamplib/begin}{artifact}
+  \socket_assign_plug:nn{tagsupport/luamplib/end}{artifact}
+  \socket_assign_plug:nn{tagsupport/luamplib/bbox}{noop}
+  \__luamplib_tag_pseudo_para_begin:
+}
+\socket_new_plug:nnn{tagsupport/luamplib/init}{off}
+{
+  \bool_set_false:N \l__luamplib_tag_was_active_bool
+  \tag_suspend:n{luamplib/init}
+}
+\socket_assign_plug:nn{tagsupport/luamplib/init}{alt}
 %    \end{macrocode}
 % Key-value options
 %    \begin{macrocode}
@@ -5632,36 +5583,24 @@ end
     ,alt .code:n =
       {
         \tl_set:Ne\l__luamplib_tag_alt_tl{\text_purify:n{#1}}
-        \socket_assign_plug:nn{tagsupport/luamplib/begin}{alt}
-        \socket_assign_plug:nn{tagsupport/luamplib/end}{alt}
-        \socket_assign_plug:nn{tagsupport/luamplib/bbox}{attr}
-        \socket_assign_plug:nn{tagsupport/luamplib/starting}{noop}
+        \socket_assign_plug:nn{tagsupport/luamplib/init}{alt}
       }
     ,actualtext .code:n =
       {
         \tl_set:Ne\l__luamplib_tag_actual_tl{\text_purify:n{#1}}
-        \socket_assign_plug:nn{tagsupport/luamplib/begin}{actualtext}
-        \socket_assign_plug:nn{tagsupport/luamplib/end}{actualtext}
-        \socket_assign_plug:nn{tagsupport/luamplib/bbox}{noop}
-        \socket_assign_plug:nn{tagsupport/luamplib/starting}{actualtext}
+        \socket_assign_plug:nn{tagsupport/luamplib/init}{actualtext}
       }
     ,artifact .code:n =
       {
-        \socket_assign_plug:nn{tagsupport/luamplib/begin}{artifact}
-        \socket_assign_plug:nn{tagsupport/luamplib/end}{artifact}
-        \socket_assign_plug:nn{tagsupport/luamplib/bbox}{noop}
-        \socket_assign_plug:nn{tagsupport/luamplib/starting}{noop}
+        \socket_assign_plug:nn{tagsupport/luamplib/init}{artifact}
       }
     ,text .code:n =
       {
-        \socket_assign_plug:nn{tagsupport/luamplib/begin}{artifact}
-        \socket_assign_plug:nn{tagsupport/luamplib/end}{artifact}
-        \socket_assign_plug:nn{tagsupport/luamplib/bbox}{noop}
-        \socket_assign_plug:nn{tagsupport/luamplib/starting}{text}
+        \socket_assign_plug:nn{tagsupport/luamplib/init}{text}
       }
     ,off .code:n =
       {
-        \socket_assign_plug:nn{tagsupport/luamplib/starting}{off}
+        \socket_assign_plug:nn{tagsupport/luamplib/init}{off}
       }
     ,tag .code:n =
       {
@@ -5675,7 +5614,7 @@ end
             \tl_set:Nn\l__luamplib_tag_struct_tl{#1}
           }
       }
-    ,correct-BBox .code:n =
+    ,adjust-BBox .code:n =
       {
         \bool_set_true:N \l__luamplib_tag_bboxcorr_bool
         \seq_set_split:Nnn \l__luamplib_tag_bboxcorr_seq{~}{#1~0pt~0pt~0pt~0pt}
@@ -5696,8 +5635,8 @@ end
 %    \begin{macrocode}
 \cs_set_nopar:Npn \mplibstarttoPDF #1 #2 #3 #4
   {
-    \prependtomplibbox
     \hbox dir TLT\bgroup
+    \bool_if:NT \l__luamplib_tag_was_active_bool { \tag_resume:n{\mplibstarttoPDF} }
     \tag_socket_use:n{luamplib/begin}
     \xdef\MPllx{#1}\xdef\MPlly{#2}%
     \xdef\MPurx{#3}\xdef\MPury{#4}%
@@ -5741,23 +5680,23 @@ end
     \keys_set:nV {luamplib/instance} \l_tmpa_tl
     \tl_if_empty:NF \currentmpinstancename
       { \tl_set:Nn\l__luamplib_tag_alt_dflt_tl {metapost~figure~\currentmpinstancename} }
-    \tag_socket_use:n{luamplib/starting}
+    \prependtomplibbox
+    \tag_socket_use:n{luamplib/init}
     \mplibtmptoks{}\ltxdomplibcode
   }
 \RenewDocumentCommand\mpfig{s O{}}
   {
     \begingroup
+    \tl_set:Nn \l__luamplib_tag_envname_tl {mpfig}
+    \keys_set_known:neN {luamplib/tag} {#2} \l_tmpa_tl
+    \keys_set:nV {luamplib/instance} \l_tmpa_tl
+    \tl_if_empty:NF \mpfiginstancename
+      { \tl_set:Nn\l__luamplib_tag_alt_dflt_tl {metapost~figure~\mpfiginstancename} }
+    \prependtomplibbox
+    \tag_socket_use:n{luamplib/init}
     \IfBooleanTF{#1}
-    {\mplibprempfig *}
-    {
-      \tl_set:Nn \l__luamplib_tag_envname_tl {mpfig}
-      \keys_set_known:neN {luamplib/tag} {#2} \l_tmpa_tl
-      \keys_set:nV {luamplib/instance} \l_tmpa_tl
-      \tl_if_empty:NF \mpfiginstancename
-        { \tl_set:Nn\l__luamplib_tag_alt_dflt_tl {metapost~figure~\mpfiginstancename} }
-      \tag_socket_use:n{luamplib/starting}
-      \mplibmainmpfig
-    }
+      { \mplibprempfig * }
+      { \mplibmainmpfig }
   }
 \RenewDocumentCommand\usemplibgroup{O{} m}
   {
@@ -5766,8 +5705,10 @@ end
     \keys_set_known:neN {luamplib/tag} {#1} \l_tmpa_tl
     \keys_set:nV {luamplib/instance} \l_tmpa_tl
     \tl_set:Nn\l__luamplib_tag_alt_dflt_tl {metapost~figure~#2}
-    \tag_socket_use:n{luamplib/starting}
-    \prependtomplibbox\hbox dir TLT\bgroup
+    \prependtomplibbox
+    \tag_socket_use:n{luamplib/init}
+    \hbox dir TLT\bgroup
+    \bool_if:NT \l__luamplib_tag_was_active_bool { \tag_resume:n{\usemplibgroup} }
     \tag_socket_use:n{luamplib/begin}
     \setbox\mplibscratchbox\hbox\bgroup
     \tag_socket_use:n{luamplib/mplibgroup/begin}

--- a/luamplib.dtx
+++ b/luamplib.dtx
@@ -558,10 +558,9 @@ See source file '\inFileName' for licencing and contact information.
 % When \pkg{tagpdf} package is loaded and activated, |mplibcode| environment accepts additional options for tagged PDF\@.
 % The code related to this functionality is currently in experimental stage, not guaranteeing backward compatibility.
 % Similar to the \LaTeX's |picture| environment,
-% available optional keys are |alt|, |actualtext|, |artifact|, |text|, |off|, |correct-BBox|,
+% available optional keys are |alt|, |actualtext|, |artifact|, |text|, |off|, |tag|, |correct-BBox|,
 % and |tagging-setup|.
 % (|texdoc| |latex-lab-graphic|).
-% In addition, we also provide the |tag| key.
 % \begin{description}
 % \item[\texttt{alt=}\meta{text}] starts a |Figure| tag by default and
 %   sets an alternate text of the figure from the \meta{text}.
@@ -574,7 +573,7 @@ See source file '\inFileName' for licencing and contact information.
 %   (that is replacement text) from the \meta{text}.
 %   BBox info will not be added.
 %   Horizontal mode is forced by \cs{noindent} or \cs{leavevmode} command
-%   according to the definition of \cs{prependtomplibbox}.\footnote{%
+%   according to the definition of \cs{prependtomplibbox}.\footnote{\relax
 %     But the vertical mode will be restored after the mplibcode environment,
 %     if it is started in a vertical mode.
 %     Anyway, it is not recommended to personally redefine \cs{prependtomplibbox}.
@@ -592,7 +591,7 @@ See source file '\inFileName' for licencing and contact information.
 %   (such as |btex| |...| |etex|, excluding pictures made by |infont| operator).
 %   BBox info will not be added.
 %   Horizontal mode is forced by \cs{noindent} or \cs{leavevmode} command
-%   according to the definition of \cs{prependtomplibbox}.\footnote{%
+%   according to the definition of \cs{prependtomplibbox}.\footnote{\relax
 %     |text| key also shares the limitation mentioned in the previous footnote.}
 %   This key is intended for figures whose meaning is the sequence of texts in the
 %   tex-text boxes in the order they are drawn in the figure.
@@ -600,18 +599,20 @@ See source file '\inFileName' for licencing and contact information.
 % \item[\texttt{off}] Unlike the same key of |picture| environment, tagging is deactivated by this option.
 %   It is another but simpler way to declare the option |tag=false|.
 %   Horizontal mode is forced by \cs{noindent} or \cs{leavevmode} command
-%   according to the definition of \cs{prependtomplibbox}.\footnote{%
+%   according to the definition of \cs{prependtomplibbox}.\footnote{\relax
 %     |off| key also shares the limitation mentioned in the previous footnote.}
+%   It is up to you to embrace the \metapost figure by proper tagging commands.
 % \item[\texttt{tag=}\meta{name}] You can choose a tag name, default value being |Figure|.
-%   For instance, you can set `|tag=Formula,| |alt=|\meta{text} to get
-%   a |Formula| structure with its alternate text.
-%   But when the value is |false|, it is a synonym of the |off| option just mentioned.
+%   For instance, you can set `|tag=Formula,| |alt=|\meta{text}' to get
+%   a |Formula| structure with its alternate text.\footnote{But now the |text| key
+%     with \pkg{unicode-math} package loaded seems to be better than |tag=Formula| option.}
+%   However, when the value is |false|, it is a synonym of the |off| option just mentioned.
 % \item[\texttt{correct-BBox=}\meta{dimens}] You can correct the BBox attribute of the figure
-%   with space-separated four dimensional values, which will be added to the
+%   by space-separated four dimensional values, which will be added to the
 %   automatically-calculated BBox values.
-%   To draw the bounding box for checking, you can declare
-%   |\DocumentMetadata|\allowbreak|{debug=BBox}|
-%   after |\DocumentMetadata{tagging=|\allowbreak|on}| setup is completed.
+%   To draw the bounding box for checking with half-transparent red color, you can declare
+%   |\DocumentMetadata|\allowbreak|{debug=|\allowbreak|BBox}| after the setup
+%   |\DocumentMetadata|\allowbreak|{tagging=|\allowbreak|on}| is completed.
 % \item[\texttt{tagging-setup=}\meta{key-val list}]
 %   This key accepts as its value the list of key-value options mentioned so far.
 % \end{description}
@@ -5236,6 +5237,7 @@ end
 \bool_new:N \g__luamplib_tag_asgroup_bool
 \bool_new:N\l__luamplib_tag_bboxcorr_bool
 \seq_new:N\l__luamplib_tag_bboxcorr_seq
+\tl_new:N \l__luamplib_tag_bbox_draw_tl
 \tl_new:N \l__luamplib_BBox_label_tl
 \tl_new:N \l__luamplib_BBox_llx_tl
 \tl_new:N \l__luamplib_BBox_lly_tl
@@ -5401,6 +5403,7 @@ end
 }
 \socket_new_plug:nnn{tagsupport/luamplib/end}{alt}
 {
+    \tl_use:N \l__luamplib_tag_bbox_draw_tl
     \tag_mc_end:
     \tag_struct_end:
     \tag_mc_begin_pop:n{}
@@ -5520,25 +5523,21 @@ end
             \l__luamplib_BBox_urx_tl\c_space_tl
             \l__luamplib_BBox_ury_tl
           }
-        \use:e
+        \tl_set:Ne \l__luamplib_tag_bbox_draw_tl
         {
-          \AddToHookNext{shipout/foreground}
+          \pdfextension save\relax
+          \color_group_begin:
+          \opacity_select:n{0.5} \color_select:n{red}
+          \pdfextension literal~text
           {
-            \exp_not:N\int_compare:nNnT
-            {\exp_not:N\g_shipout_readonly_int}
-            =
-            {\property_ref:een{\l__luamplib_BBox_label_tl}{abspage}{0}}
-            {
-              \exp_not:N\put
-              (\l__luamplib_BBox_llx_tl bp, \dim_eval:n{\l__luamplib_BBox_lly_tl bp -\paperheight})
-              {
-                \opacity_select:n{0.5} \color_select:n{red}
-                \exp_not:N\rule
-                  {\dim_eval:n {\l__luamplib_BBox_urx_tl bp - \l__luamplib_BBox_llx_tl bp}}
-                  {\dim_eval:n {\l__luamplib_BBox_ury_tl bp - \l__luamplib_BBox_lly_tl bp}}
-              }
-            }
+            \l__luamplib_BBox_llx_tl\c_space_tl
+            \l__luamplib_BBox_lly_tl\c_space_tl
+            \fp_eval:n { \l__luamplib_BBox_urx_tl - \l__luamplib_BBox_llx_tl }~
+            \fp_eval:n { \l__luamplib_BBox_ury_tl - \l__luamplib_BBox_lly_tl }~
+            re~f
           }
+          \color_group_end:
+          \pdfextension restore\relax
         }
       }
 }

--- a/test-luamplib-latex.tex
+++ b/test-luamplib-latex.tex
@@ -258,7 +258,7 @@ draw mpliboutlinetext.b ("$\displaystyle\frac{1}{1-x^2}$")
   xstep = 5, ystep = 6,
   matrix = "rotated 90 scaled .75",
 ]
-\mpfig[tag=false]
+\mpfig[off]
 draw (origin--right+up) scaled 5 withcolor 1/3[blue,white] ;
 draw (up--right) scaled 5 withcolor 1/3[red,white] ;
 \endmpfig

--- a/test-luamplib-latex.tex
+++ b/test-luamplib-latex.tex
@@ -342,20 +342,12 @@ filldraw fullcircle scaled 100 withmppattern "mypatt" withpen pencircle scaled 1
 \usemplibgroup{test:isolated,knockout}%
 \begin{mplibgroup}{mytex}[matrix="rotated 15"] \SuspendTagging{}\TeX \end{mplibgroup}%
 \ExplSyntaxOn
-\tag_if_active:T
-{
-  \tag_mc_end_push:
-  \tag_mc_begin:n{artifact}
-}
+\tag_mc_artifact_group_begin:n {}
 \ExplSyntaxOff
 \hbox to0pt{\hss\vrule width.5pt height5pt depth5pt\hss}%
 \hbox to0pt{\hss\vrule width10pt height.25pt depth.25pt\hss}%
 \ExplSyntaxOn
-\tag_if_active:T
-{
-  \tag_mc_end:
-  \tag_mc_begin_pop:n{}
-}
+\tag_mc_artifact_group_end:
 \ExplSyntaxOff
 \usemplibgroup[actualtext=TeX]{mytex}%
 \mpfig[actualtext=TeX] usemplibgroup "mytex"; draw (left--right) scaled 5; draw (up--down) scaled 5; \endmpfig

--- a/test-luamplib-latex.tex
+++ b/test-luamplib-latex.tex
@@ -62,7 +62,8 @@ label.bot(btex $x$ etex, (2u,0));
 label.lft(btex $y$ etex, (0,u));
 endfig;
 \end{mplibcode}%
-B\par
+B%
+
 A%
 \begin{mplibcode}
 beginfig(2);
@@ -81,7 +82,7 @@ B%
 \mplibcodeinherit{enable}%
 \mplibglobaltextext{enable}%
 \everymplib{ beginfig(0);}\everyendmplib{ endfig;}%
-\begin{mplibcode}
+\begin{mplibcode}[text]
  label(btex $\sqrt{2}$ etex, origin);
  draw fullcircle scaled 20;
  picture pic; pic := currentpicture;
@@ -93,9 +94,8 @@ B%
 \everymplib{}\everyendmplib{}%
 \mplibcodeinherit{disable}%
 \mplibglobaltextext{disable}\par
-\SuspendTagging{}%
 \mplibsetformat{metafun}%
-\begin{mplibcode}
+\begin{mplibcode}[alt=alt inside mp code]
 message "Hello World!";
 verbatimtex \moveright 0.4\hsize etex
 beginfig(0);
@@ -110,16 +110,15 @@ beginfig(1);
 linear_shade(bbox p,0,blue,.7white);
 draw p withcolor white;
 endfig;
-verbatimtex \mplibalttext{MetaPost}\kern10pt etex
+verbatimtex \mplibalttext{MetaPost again}\kern10pt etex
 beginfig(2);
 circular_shade(bbox p,0,blue,.7white);
 draw p withcolor white;
 endfig;
 \end{mplibcode}%
 
-\ResumeTagging{}%
 \begin{mplibgroup}{mympbox}%
-\begin{mplibcode}[tag=false]
+\begin{mplibcode}[off]
 %verbatimtex \global\setbox\mympbox etex
 beginfig(0);
 breadth=.667\mpdim\linewidth;
@@ -138,7 +137,7 @@ endfig;
 
 \mplibnoforcehmode
 \mplibnumbersystem{double}%
-\begin{mplibcode}
+\begin{mplibcode}[off]
 beginfig(0);
 u := 10**5*(10**-4);
 draw unitsquare scaled u;
@@ -158,13 +157,13 @@ endfig;
   endfig;
 \end{mplibcode}%
 \mplibtextextlabel{enable}%
-\begin{mplibcode}[tag=Formula,alt=$sqrt 2$]
+\begin{mplibcode}[text] %[tag=Formula,alt=$sqrt 2$]
 beginfig(0);
 dotlabel.rt("$\sqrt2$",origin);
 endfig;
 \end{mplibcode}%
 \leavevmode
-\begin{mplibcode}
+\begin{mplibcode}[artifact]
    D := sqrt(2)**7;
    beginfig(0);
    draw fullcircle scaled D;
@@ -172,7 +171,7 @@ endfig;
    endfig;
 \end{mplibcode}%
 diameter:\Dia bp.%
-\begin{mplibcode}[text]
+\begin{mplibcode}[off]
   vardef rotatedlabel@#(expr str, loc, angl) =
     draw thelabel@#(str, loc) rotatedaround(loc, angl)
   enddef;
@@ -277,7 +276,7 @@ filldraw fullcircle scaled 100 withmppattern "mypatt" withpen pencircle scaled 1
   \SuspendTagging{}%
   \tiny\TeX
 \end{mppattern}\relax
-\mpfig[alt=TeX]
+\mpfig[actualtext=TeX]
   picture tex;
   tex = mpliboutlinetext.p ("\bfseries \TeX");
   for i=1 upto mpliboutlinenum:
@@ -301,7 +300,7 @@ filldraw fullcircle scaled 100 withmppattern "mypatt" withpen pencircle scaled 1
 \endmpfig
 
 \leavevmode
-\mpfig
+\mpfig[test fading]
   picture mill; mill = btex \includegraphics[width=100bp]{mill} etex;
   draw mill;
   mill := mill shifted 125right;
@@ -364,7 +363,7 @@ filldraw fullcircle scaled 100 withmppattern "mypatt" withpen pencircle scaled 1
     ;
 \endmpfig
 \leavevmode
-\mpfig[text]
+\mpfig[off]
   string Test; Test="abçdéf";
   for k=0 upto mpliblength(Test)-1:
     draw TEX(mplibsubstring (k,k+1) of Test) scaled 2 shifted (20k,0);
@@ -381,21 +380,21 @@ filldraw fullcircle scaled 100 withmppattern "mypatt" withpen pencircle scaled 1
 \endmpfig
 
 \mppattern{p1}
-  \mpfig[tag=false]
+  \mpfig[off]
     fill fullcircle scaled 3
     withcolor .7red
     ;
   \endmpfig
 \endmppattern
 \mppattern{p2}
-  \mpfig[tag=false]
+  \mpfig[off]
     fill fullcircle scaled 9
     withmppattern "p1"
     ;
   \endmpfig
 \endmppattern
 \mppattern{p3}
-  \mpfig[tag=false]
+  \mpfig[off]
     fill fullcircle scaled 27
     withmppattern "p2"
     ;

--- a/test-luamplib-latex.tex
+++ b/test-luamplib-latex.tex
@@ -14,9 +14,7 @@
 \everyendmplib{ endfig; }
 \mpliblegacybehavior{true}%
 \begin{document}
-\ExplSyntaxOn
-\tag_if_active:T { \keys_set:nn{luamplib/tagging}{alt=testing} }
-\ExplSyntaxOff
+\mplibalttext{testing}
 \tracingcommands1
 A%
 \begin{mplibcode}
@@ -344,12 +342,20 @@ filldraw fullcircle scaled 100 withmppattern "mypatt" withpen pencircle scaled 1
 \usemplibgroup{test:isolated,knockout}%
 \begin{mplibgroup}{mytex}[matrix="rotated 15"] \SuspendTagging{}\TeX \end{mplibgroup}%
 \ExplSyntaxOn
-\tag_if_active:T { \tag_mc_begin:n{artifact} }
+\tag_if_active:T
+{
+  \tag_mc_end_push:
+  \tag_mc_begin:n{artifact}
+}
 \ExplSyntaxOff
 \hbox to0pt{\hss\vrule width.5pt height5pt depth5pt\hss}%
 \hbox to0pt{\hss\vrule width10pt height.25pt depth.25pt\hss}%
 \ExplSyntaxOn
-\tag_if_active:T { \tag_mc_end: }
+\tag_if_active:T
+{
+  \tag_mc_end:
+  \tag_mc_begin_pop:n{}
+}
 \ExplSyntaxOff
 \usemplibgroup[actualtext=TeX]{mytex}%
 \mpfig[actualtext=TeX] usemplibgroup "mytex"; draw (left--right) scaled 5; draw (up--down) scaled 5; \endmpfig

--- a/test-luamplib-latex.tex
+++ b/test-luamplib-latex.tex
@@ -93,6 +93,7 @@ B%
 \everymplib{}\everyendmplib{}%
 \mplibcodeinherit{disable}%
 \mplibglobaltextext{disable}\par
+\SuspendTagging{}%
 \mplibsetformat{metafun}%
 \begin{mplibcode}
 message "Hello World!";
@@ -116,6 +117,7 @@ draw p withcolor white;
 endfig;
 \end{mplibcode}%
 
+\ResumeTagging{}%
 \begin{mplibgroup}{mympbox}%
 \begin{mplibcode}[tag=false]
 %verbatimtex \global\setbox\mympbox etex
@@ -180,7 +182,7 @@ diameter:\Dia bp.%
   endfig;
 \end{mplibcode}%
 
-\begin{mplibcode}[actualtext=Funny $sqrt{2}$ xyz]
+\begin{mplibcode}[alt=Funny $sqrt{2}$ xyz]
 beginfig(1)
   draw mplibgraphictext "\bfseries Funny$\sqrt{2}$"
   fakebold 2 % fontspec option
@@ -191,7 +193,7 @@ endfig;
 \end{mplibcode}%
 
 %\mplibsetformat{metafun}%
-\begin{mplibcode}
+\begin{mplibcode}[alt=testing shading]
 beginfig(1)
 fill unitsquare xscaled \mpdim\textwidth yscaled 1cm
     withshadingmethod "linear"

--- a/test-luamplib-latex.tex
+++ b/test-luamplib-latex.tex
@@ -343,12 +343,12 @@ filldraw fullcircle scaled 100 withmppattern "mypatt" withpen pencircle scaled 1
 \usemplibgroup[actualtext=TeX]{mytex}%
 \mpfig[actualtext=TeX] usemplibgroup "mytex"; draw (left--right) scaled 5; draw (up--down) scaled 5; \endmpfig
 
-\mpfig[actualtext=MPLIB]
+\mpfig[text]
   draw mplibgraphictext "\textbf{MPLIB}"
     fakebold 1 fillcolor "red!70" drawcolor .7red scaled 7
     withmppattern "mypatt" ;
 \endmpfig
-\mpfig[actualtext=TeX]
+\mpfig[text]
   draw mplibgraphictext "\bfseries\TeX" rotated 30 scaled 4
     withshadingmethod "linear"
     withshadingvector (3,0)
@@ -356,7 +356,7 @@ filldraw fullcircle scaled 100 withmppattern "mypatt" withpen pencircle scaled 1
     ;
 \endmpfig
 \leavevmode
-\mpfig[alt=testing]
+\mpfig[text]
   string Test; Test="abçdéf";
   for k=0 upto mpliblength(Test)-1:
     draw TEX(mplibsubstring (k,k+1) of Test) scaled 2 shifted (20k,0);

--- a/test-luamplib-latex.tex
+++ b/test-luamplib-latex.tex
@@ -15,7 +15,7 @@
 \mpliblegacybehavior{true}%
 \begin{document}
 \ExplSyntaxOn
-\keys_set:nn{luamplib/tag}{alt=testing}
+\keys_set:nn{luamplib/tagging}{alt=testing}
 \ExplSyntaxOff
 \tracingcommands1
 A%
@@ -157,7 +157,7 @@ endfig;
   endfig;
 \end{mplibcode}%
 \mplibtextextlabel{enable}%
-\begin{mplibcode}[text] %[tag=Formula,alt=$sqrt 2$]
+\begin{mplibcode}[text]
 beginfig(0);
 dotlabel.rt("$\sqrt2$",origin);
 endfig;
@@ -233,7 +233,7 @@ endfor
 \mpfig* input boxes \endmpfig
 \mpfig circleit.a(btex\tracingcommands0 Box 1 etex); drawboxed(a); \endmpfig
 \def\mpfiginstancename{mympfig}%
-\mpfig[actualtext=$1/(1-x^2)$]
+\mpfig[tag=Formula,alt=$1/(1-x^2)$]
 draw mpliboutlinetext.b ("$\displaystyle\frac{1}{1-x^2}$")
     (withcolor .6[red,white])
     (withpen pencircle scaled .2 withcolor red)

--- a/test-luamplib-latex.tex
+++ b/test-luamplib-latex.tex
@@ -1,5 +1,6 @@
 \ifnum\outputmode > 0
   \DocumentMetadata{ lang=en-US, pdfversion=2.0, pdfstandard=ua-2, tagging=on }
+%  \DocumentMetadata{ debug=BBox }
   \documentclass{article}
 \else
   \documentclass[dvipdfmx]{article}
@@ -152,11 +153,9 @@ endfig;
   endfig;
 \end{mplibcode}%
 \mplibtextextlabel{enable}%
-\begin{mplibcode}[tag=Formula,alt=sqrt 2]
+\begin{mplibcode}[tag=Formula,alt=$sqrt 2$]
 beginfig(0);
 dotlabel.rt("$\sqrt2$",origin);
-% the last textext with math formula seems to be problemaric in text-keyed figures.
-% draw btex \relax etex;
 endfig;
 \end{mplibcode}%
 \leavevmode
@@ -168,7 +167,7 @@ endfig;
    endfig;
 \end{mplibcode}%
 diameter:\Dia bp.%
-\begin{mplibcode}[actualtext=Rotated!]
+\begin{mplibcode}[text]
   vardef rotatedlabel@#(expr str, loc, angl) =
     draw thelabel@#(str, loc) rotatedaround(loc, angl)
   enddef;
@@ -178,10 +177,7 @@ diameter:\Dia bp.%
   endfig;
 \end{mplibcode}%
 
-% what is the "mc on page 1"?
-% the issue must be related to page changing. Force horiz mode.
-\noindent
-\begin{mplibcode}[actualtext=Funny square root 2 xyz]
+\begin{mplibcode}[actualtext=Funny $sqrt{2}$ xyz]
 beginfig(1)
   draw mplibgraphictext "\bfseries Funny$\sqrt{2}$"
   fakebold 2 % fontspec option
@@ -233,7 +229,7 @@ endfor
 \mpfig* input boxes \endmpfig
 \mpfig[alt=testing] circleit.a(btex\tracingcommands0 Box 1 etex); drawboxed(a); \endmpfig
 \def\mpfiginstancename{mympfig}%
-\mpfig[actualtext=1/(1-x^2)]
+\mpfig[actualtext=$1/(1-x^2)$]
 draw mpliboutlinetext.b ("$\displaystyle\frac{1}{1-x^2}$")
     (withcolor .6[red,white])
     (withpen pencircle scaled .2 withcolor red)

--- a/test-luamplib-latex.tex
+++ b/test-luamplib-latex.tex
@@ -180,9 +180,7 @@ beginfig(1)
   fakebold 2 % fontspec option
   drawcolor blue fillcolor "red!50" % l3color expression
   scaled 3 rotated 30 ;
-picture p;
-p:=mplibgraphictext "\bfseries\itshape xyz";
-draw p scaled 3 shifted (40,0);
+draw mplibgraphictext "\bfseries\itshape xyz" scaled 3 shifted (40,0);
 endfig;
 \end{mplibcode}%
 \par
@@ -341,14 +339,12 @@ filldraw fullcircle scaled 100 withmppattern "mypatt" withpen pencircle scaled 1
 \mpfig usemplibgroup "mytex"; draw (left--right) scaled 5; draw (up--down) scaled 5; \endmpfig
 \par
 \mpfig
-  picture test; test = mplibgraphictext "\textbf{MPLIB}"
-    fakebold 1 fillcolor "red!70" drawcolor .7red scaled 7;
-  draw test withmppattern "mypatt" ;
+  draw mplibgraphictext "\textbf{MPLIB}"
+    fakebold 1 fillcolor "red!70" drawcolor .7red scaled 7
+    withmppattern "mypatt" ;
 \endmpfig
 \mpfig
-  picture tex;
-  tex = mplibgraphictext "\bfseries\TeX" rotated 30 scaled 4;
-  draw tex
+  draw mplibgraphictext "\bfseries\TeX" rotated 30 scaled 4
     withshadingmethod "linear"
     withshadingvector (3,0)
     withshadingcolors (red,blue)

--- a/test-luamplib-latex.tex
+++ b/test-luamplib-latex.tex
@@ -1,5 +1,5 @@
-%\DocumentMetadata{ uncompress }
 \ifnum\outputmode > 0
+  \DocumentMetadata{ lang=en-US, pdfversion=2.0, pdfstandard=ua-2, tagging=on }
   \documentclass{article}
 \else
   \documentclass[dvipdfmx]{article}
@@ -8,14 +8,14 @@
 \setmainfont{latin modern roman}
 \newfontfamily\hangulfont{NotoSansCJKKR}[Script=Hangul,Language=Korean]
 \usepackage{luamplib}
-\usepackage{graphicx,xcolor}
+\usepackage{unicode-math,graphicx,xcolor}
 \everymplib{ beginfig(0); }
 \everyendmplib{ endfig; }
 \mpliblegacybehavior{true}%
 \begin{document}
 \tracingcommands1
 A%
-\begin{mplibcode}
+\begin{mplibcode}[alt=testing]
 %% test all printable ascii chars in comments
 %%    (  2  <  F  P  Z  d   n   x
 %%    )  3  =  G  Q  [  e   o   y
@@ -32,7 +32,7 @@ A%
 B\par
 \everymplib{}\everyendmplib{}% reset toks
 A%
-\begin{mplibcode}
+\begin{mplibcode}[alt=testing]
 verbatimtex \lower.2em etex
 beginfig(0);
 draw origin--(1cm,0) withcolor \mpcolor{teal};
@@ -60,7 +60,7 @@ endfig;
 \end{mplibcode}%
 B\par
 A%
-\begin{mplibcode}
+\begin{mplibcode}[alt=testing]
 beginfig(2);
 numeric u; u=1cm;
 z1=-z2=(-u,0);
@@ -71,16 +71,18 @@ for i = 1 upto 3:
 endfor;
 endfig;
 \end{mplibcode}%
-B\par\mplibforcehmode
+B%
+
+\mplibforcehmode
 \mplibcodeinherit{enable}%
 \mplibglobaltextext{enable}%
 \everymplib{ beginfig(0);}\everyendmplib{ endfig;}%
-\begin{mplibcode}
+\begin{mplibcode}[alt=testing]
  label(btex $\sqrt{2}$ etex, origin);
  draw fullcircle scaled 20;
  picture pic; pic := currentpicture;
 \end{mplibcode}%
-\begin{mplibcode}
+\begin{mplibcode}[alt=testing]
  currentpicture := pic scaled 2;
 \end{mplibcode}%
 \mplibnoforcehmode
@@ -88,7 +90,7 @@ B\par\mplibforcehmode
 \mplibcodeinherit{disable}%
 \mplibglobaltextext{disable}\par
 \mplibsetformat{metafun}%
-\begin{mplibcode}
+\begin{mplibcode}[alt=testing]
 message "Hello World!";
 verbatimtex \moveright 0.4\hsize etex
 beginfig(0);
@@ -110,9 +112,8 @@ draw p withcolor white;
 endfig;
 \end{mplibcode}%
 
-\newbox\mympbox
-\def\prependtomplibbox{\global\setbox\mympbox}%
-\begin{mplibcode}
+\begin{mplibgroup}{mympbox}%
+\begin{mplibcode}[tag=false]
 %verbatimtex \global\setbox\mympbox etex
 beginfig(0);
 breadth=.667\mpdim\linewidth;
@@ -123,21 +124,22 @@ y1=y4=height/2; y2=y3=height; y5=y6=0;
 fill z1--z2--z3--z4--z5--z6--cycle;
 endfig;
 \end{mplibcode}%
-\copy\mympbox
-\copy\mympbox
-\copy\mympbox
-\copy\mympbox
+\end{mplibgroup}%
+\usemplibgroup[artifact]{mympbox}%
+\usemplibgroup[artifact]{mympbox}%
+\usemplibgroup[artifact]{mympbox}%
+\usemplibgroup[artifact]{mympbox}%
 
 \mplibnoforcehmode
 \mplibnumbersystem{double}%
-\begin{mplibcode}
+\begin{mplibcode}[alt=testing]
 beginfig(0);
 u := 10**5*(10**-4);
 draw unitsquare scaled u;
 endfig;
 \end{mplibcode}%
 \mplibsetformat{plain}%
-\begin{mplibcode}
+\begin{mplibcode}[alt=testing]
   input graph;
   beginfig(0);
   draw begingraph(100,100);
@@ -150,13 +152,15 @@ endfig;
   endfig;
 \end{mplibcode}%
 \mplibtextextlabel{enable}%
-\begin{mplibcode}
+\begin{mplibcode}[tag=Formula,alt=sqrt 2]
 beginfig(0);
 dotlabel.rt("$\sqrt2$",origin);
+% the last textext with math formula seems to be problemaric in text-keyed figures.
+% draw btex \relax etex;
 endfig;
 \end{mplibcode}%
 \leavevmode
-\begin{mplibcode}
+\begin{mplibcode}[alt=testing]
    D := sqrt(2)**7;
    beginfig(0);
    draw fullcircle scaled D;
@@ -164,17 +168,20 @@ endfig;
    endfig;
 \end{mplibcode}%
 diameter:\Dia bp.%
-\begin{mplibcode}
+\begin{mplibcode}[actualtext=Rotated!]
   vardef rotatedlabel@#(expr str, loc, angl) =
     draw thelabel@#(str, loc) rotatedaround(loc, angl)
   enddef;
 
   beginfig(1);
-    rotatedlabel.top(textext "Rotated!", origin, 45);
+    rotatedlabel.top(textext "Rotated!", origin, 40);
   endfig;
 \end{mplibcode}%
-\par
-\begin{mplibcode}
+
+% what is the "mc on page 1"?
+% the issue must be related to page changing. Force horiz mode.
+\noindent
+\begin{mplibcode}[actualtext=Funny square root 2 xyz]
 beginfig(1)
   draw mplibgraphictext "\bfseries Funny$\sqrt{2}$"
   fakebold 2 % fontspec option
@@ -183,9 +190,9 @@ beginfig(1)
 draw mplibgraphictext "\bfseries\itshape xyz" scaled 3 shifted (40,0);
 endfig;
 \end{mplibcode}%
-\par
+
 %\mplibsetformat{metafun}%
-\begin{mplibcode}
+\begin{mplibcode}[alt=testing]
 beginfig(1)
 fill unitsquare xscaled \mpdim\textwidth yscaled 1cm
     withshadingmethod "linear"
@@ -202,7 +209,7 @@ fill unitsquare xscaled \mpdim\textwidth yscaled 1cm
 endfig;
 \end{mplibcode}%
 \leavevmode
-\mpfig
+\mpfig[actualtext=Que]
 color yellow; yellow = (1,1,0);
 picture Q, u, e;
 Q := mplibglyph "Q" of "texgyrepagella-bolditalic.otf" scaled .1;
@@ -224,16 +231,16 @@ endfor
 \endmpfig
 \everymplib[@mpfig]{ drawoptions(withcolor mplibrgbtexcolor "olive"); }%
 \mpfig* input boxes \endmpfig
-\mpfig circleit.a(btex\tracingcommands0 Box 1 etex); drawboxed(a); \endmpfig
+\mpfig[alt=testing] circleit.a(btex\tracingcommands0 Box 1 etex); drawboxed(a); \endmpfig
 \def\mpfiginstancename{mympfig}%
-\mpfig
+\mpfig[actualtext=1/(1-x^2)]
 draw mpliboutlinetext.b ("$\displaystyle\frac{1}{1-x^2}$")
     (withcolor .6[red,white])
     (withpen pencircle scaled .2 withcolor red)
     scaled 4 ;
 \endmpfig
-\par
-\mpfig
+
+\mpfig[actualtext=Question]
   draw mpliboutlinetext.r
     ("Question")
     ( withpen pencircle scaled .3 )
@@ -244,18 +251,19 @@ draw mpliboutlinetext.b ("$\displaystyle\frac{1}{1-x^2}$")
     )
     scaled 4;
 \endmpfig
-\par\leavevmode
+
+\leavevmode
 \mppattern{mypatt}
 [
   xstep = 5, ystep = 6,
   matrix = "rotated 90 scaled .75",
 ]
-\mpfig
+\mpfig[tag=false]
 draw (origin--right+up) scaled 5 withcolor 1/3[blue,white] ;
 draw (up--right) scaled 5 withcolor 1/3[red,white] ;
 \endmpfig
 \endmppattern
-\mpfig
+\mpfig[alt=testing]
 draw unitsquare shifted -center unitsquare scaled 45 withpostscript "collect" ;
 filldraw fullcircle scaled 100 withmppattern "mypatt" withpen pencircle scaled 1
   withcolor \mpcolor{red!50!blue!50} withpostscript "evenodd" ;
@@ -267,7 +275,7 @@ filldraw fullcircle scaled 100 withmppattern "mypatt" withpen pencircle scaled 1
   ]
   \tiny\TeX
 \end{mppattern}\relax
-\mpfig
+\mpfig[actualtext=TeX]
   picture tex;
   tex = mpliboutlinetext.p ("\bfseries \TeX");
   for i=1 upto mpliboutlinenum:
@@ -289,8 +297,9 @@ filldraw fullcircle scaled 100 withmppattern "mypatt" withpen pencircle scaled 1
     ;
   endfor
 \endmpfig
-\par\leavevmode
-\mpfig
+
+\leavevmode
+\mpfig[alt=testing]
   picture mill; mill = btex \includegraphics[width=100bp]{mill} etex;
   draw mill;
   mill := mill shifted 125right;
@@ -301,9 +310,9 @@ filldraw fullcircle scaled 100 withmppattern "mypatt" withpen pencircle scaled 1
     withfadeopacity (1, 0)
     ;
 \endmpfig
-\par
+
 \def\test#1{%
-  \mpfig
+  \mpfig[alt=testing]
   fill unitsquare shifted -center unitsquare scaled 200
     withshadingmethod "linear"
     withshadingcolors (.3[red,white], .3[blue,white])
@@ -330,20 +339,20 @@ filldraw fullcircle scaled 100 withmppattern "mypatt" withpen pencircle scaled 1
 \hbox{\test{knockout}\,\test{}}%
 \hbox to\MPwidth{\hss knockout\hss}%
 \leavevmode
-\mpfig usemplibgroup "test:isolated,knockout" scaled 2/3 rotated 15 ; \endmpfig
-\usemplibgroup{test:isolated,knockout}%
+\mpfig[alt=testing] usemplibgroup "test:isolated,knockout" scaled 2/3 rotated 15 ; \endmpfig
+\usemplibgroup[alt=testing]{test:isolated,knockout}%
 \begin{mplibgroup}{mytex}[matrix="rotated 15"] \TeX \end{mplibgroup}%
 \hbox to0pt{\hss\vrule width.5pt height5pt depth5pt\hss}%
 \hbox to0pt{\hss\vrule width10pt height.25pt depth.25pt\hss}%
-\usemplibgroup{mytex}%
-\mpfig usemplibgroup "mytex"; draw (left--right) scaled 5; draw (up--down) scaled 5; \endmpfig
-\par
-\mpfig
+\usemplibgroup[actualtext=TeX]{mytex}%
+\mpfig[actualtext=TeX] usemplibgroup "mytex"; draw (left--right) scaled 5; draw (up--down) scaled 5; \endmpfig
+
+\mpfig[actualtext=MPLIB]
   draw mplibgraphictext "\textbf{MPLIB}"
     fakebold 1 fillcolor "red!70" drawcolor .7red scaled 7
     withmppattern "mypatt" ;
 \endmpfig
-\mpfig
+\mpfig[actualtext=TeX]
   draw mplibgraphictext "\bfseries\TeX" rotated 30 scaled 4
     withshadingmethod "linear"
     withshadingvector (3,0)
@@ -351,7 +360,7 @@ filldraw fullcircle scaled 100 withmppattern "mypatt" withpen pencircle scaled 1
     ;
 \endmpfig
 \leavevmode
-\mpfig
+\mpfig[alt=testing]
   string Test; Test="abçdéf";
   for k=0 upto mpliblength(Test)-1:
     draw TEX(mplibsubstring (k,k+1) of Test) scaled 2 shifted (20k,0);
@@ -359,36 +368,36 @@ filldraw fullcircle scaled 100 withmppattern "mypatt" withpen pencircle scaled 1
 \endmpfig
 \qquad
 \mpliblegacybehavior{false}%
-\mpfig
+\mpfig[actualtext=나랏말씀이]
   verbatimtex \hangulfont etex;
   string Test; Test="나랏말ᄊᆞ미";
   for k=0 upto mplibuclength(Test)-1:
     draw TEX(mplibucsubstring (k,k+1) of Test) scaled 1.5 shifted (20k,0);
   endfor
 \endmpfig
-\par
+
 \mppattern{p1}
-  \mpfig
+  \mpfig[tag=false]
     fill fullcircle scaled 3
     withcolor .7red
     ;
   \endmpfig
 \endmppattern
 \mppattern{p2}
-  \mpfig
+  \mpfig[tag=false]
     fill fullcircle scaled 9
     withmppattern "p1"
     ;
   \endmpfig
 \endmppattern
 \mppattern{p3}
-  \mpfig
+  \mpfig[tag=false]
     fill fullcircle scaled 27
     withmppattern "p2"
     ;
   \endmpfig
 \endmppattern
-\mpfig
+\mpfig[alt=testing]
   fill fullcircle scaled 108
   withmppattern "p3"
   ;
@@ -402,7 +411,7 @@ filldraw fullcircle scaled 100 withmppattern "mypatt" withpen pencircle scaled 1
 \everymplib[instanceOne]{beginfig(1);}
 \everyendmplib[instanceOne]{endfig;}
 
-\begin{mplibcode}[instanceOne]
+\begin{mplibcode}[instanceOne,alt=testing]
   picture TeX;
   TeX := btex \TeX etex;
 a := 1cm;
@@ -412,7 +421,7 @@ draw TeX;
 \end{mplibcode}%
 Current instance name is: \currentmpinstancename \vskip 2\baselineskip
 
-\begin{mplibcode}[instanceTwo]
+\begin{mplibcode}[instanceTwo,alt=testing]
 beginfig(1);
 if not known a:
   draw btex code is not inherited from an instance with a different name etex;
@@ -423,7 +432,7 @@ endfig;
 \end{mplibcode}%
 Current instance name is: \currentmpinstancename \vskip 2\baselineskip
 
-\begin{mplibcode}
+\begin{mplibcode}[alt=testing]
 beginfig(1);
 if not known a:
   draw btex code is not inherited if instance name is not listed etex;
@@ -435,7 +444,7 @@ endfig;
 \end{mplibcode}%
 Current instance name is: \currentmpinstancename (should be empty) \vskip 2\baselineskip
 
-\begin{mplibcode}
+\begin{mplibcode}[alt=testing]
 beginfig(1);
 if not known a:
   draw btex code is not inherited if mplibcodeinherit is disabled and instance name is not explicitly set etex;
@@ -446,7 +455,7 @@ endfig;
 \end{mplibcode}%
 Current instance name is: \currentmpinstancename (should be empty) \vskip 2\baselineskip
 
-\begin{mplibcode}[instanceOne]
+\begin{mplibcode}[instanceOne,alt=testing]
 draw unitsquare scaled a;
 draw btex a square with side $=a$, inherited from the same instance etex shifted (3/2a, 1/2a);
   draw TeX;

--- a/test-luamplib-latex.tex
+++ b/test-luamplib-latex.tex
@@ -15,7 +15,7 @@
 \mpliblegacybehavior{true}%
 \begin{document}
 \ExplSyntaxOn
-\keys_set:nn{luamplib/tagging}{alt=testing}
+\tag_if_active:T { \keys_set:nn{luamplib/tagging}{alt=testing} }
 \ExplSyntaxOff
 \tracingcommands1
 A%
@@ -300,7 +300,7 @@ filldraw fullcircle scaled 100 withmppattern "mypatt" withpen pencircle scaled 1
 \endmpfig
 
 \leavevmode
-\mpfig[test fading]
+\mpfig[alt=test fading]
   picture mill; mill = btex \includegraphics[width=100bp]{mill} etex;
   draw mill;
   mill := mill shifted 125right;
@@ -343,10 +343,14 @@ filldraw fullcircle scaled 100 withmppattern "mypatt" withpen pencircle scaled 1
 \mpfig usemplibgroup "test:isolated,knockout" scaled 2/3 rotated 15 ; \endmpfig
 \usemplibgroup{test:isolated,knockout}%
 \begin{mplibgroup}{mytex}[matrix="rotated 15"] \SuspendTagging{}\TeX \end{mplibgroup}%
-\tagmcbegin{artifact}%
+\ExplSyntaxOn
+\tag_if_active:T { \tag_mc_begin:n{artifact} }
+\ExplSyntaxOff
 \hbox to0pt{\hss\vrule width.5pt height5pt depth5pt\hss}%
 \hbox to0pt{\hss\vrule width10pt height.25pt depth.25pt\hss}%
-\tagmcend
+\ExplSyntaxOn
+\tag_if_active:T { \tag_mc_end: }
+\ExplSyntaxOff
 \usemplibgroup[actualtext=TeX]{mytex}%
 \mpfig[actualtext=TeX] usemplibgroup "mytex"; draw (left--right) scaled 5; draw (up--down) scaled 5; \endmpfig
 
@@ -414,7 +418,7 @@ filldraw fullcircle scaled 100 withmppattern "mypatt" withpen pencircle scaled 1
 \everymplib[instanceOne]{beginfig(1);}
 \everyendmplib[instanceOne]{endfig;}
 
-\begin{mplibcode}[instanceOne,alt=testing]
+\begin{mplibcode}[instanceOne]
   picture TeX;
   TeX := btex \TeX etex;
 a := 1cm;
@@ -424,7 +428,7 @@ draw TeX;
 \end{mplibcode}%
 Current instance name is: \currentmpinstancename \vskip 2\baselineskip
 
-\begin{mplibcode}[instanceTwo,alt=testing]
+\begin{mplibcode}[instanceTwo]
 beginfig(1);
 if not known a:
   draw btex code is not inherited from an instance with a different name etex;
@@ -458,7 +462,7 @@ endfig;
 \end{mplibcode}%
 Current instance name is: \currentmpinstancename (should be empty) \vskip 2\baselineskip
 
-\begin{mplibcode}[instanceOne,alt=testing]
+\begin{mplibcode}[instanceOne]
 draw unitsquare scaled a;
 draw btex a square with side $=a$, inherited from the same instance etex shifted (3/2a, 1/2a);
   draw TeX;

--- a/test-luamplib-latex.tex
+++ b/test-luamplib-latex.tex
@@ -14,9 +14,12 @@
 \everyendmplib{ endfig; }
 \mpliblegacybehavior{true}%
 \begin{document}
+\ExplSyntaxOn
+\keys_set:nn{luamplib/tag}{alt=testing}
+\ExplSyntaxOff
 \tracingcommands1
 A%
-\begin{mplibcode}[alt=testing]
+\begin{mplibcode}
 %% test all printable ascii chars in comments
 %%    (  2  <  F  P  Z  d   n   x
 %%    )  3  =  G  Q  [  e   o   y
@@ -33,7 +36,7 @@ A%
 B\par
 \everymplib{}\everyendmplib{}% reset toks
 A%
-\begin{mplibcode}[alt=testing]
+\begin{mplibcode}
 verbatimtex \lower.2em etex
 beginfig(0);
 draw origin--(1cm,0) withcolor \mpcolor{teal};
@@ -61,7 +64,7 @@ endfig;
 \end{mplibcode}%
 B\par
 A%
-\begin{mplibcode}[alt=testing]
+\begin{mplibcode}
 beginfig(2);
 numeric u; u=1cm;
 z1=-z2=(-u,0);
@@ -78,12 +81,12 @@ B%
 \mplibcodeinherit{enable}%
 \mplibglobaltextext{enable}%
 \everymplib{ beginfig(0);}\everyendmplib{ endfig;}%
-\begin{mplibcode}[alt=testing]
+\begin{mplibcode}
  label(btex $\sqrt{2}$ etex, origin);
  draw fullcircle scaled 20;
  picture pic; pic := currentpicture;
 \end{mplibcode}%
-\begin{mplibcode}[alt=testing]
+\begin{mplibcode}
  currentpicture := pic scaled 2;
 \end{mplibcode}%
 \mplibnoforcehmode
@@ -91,7 +94,7 @@ B%
 \mplibcodeinherit{disable}%
 \mplibglobaltextext{disable}\par
 \mplibsetformat{metafun}%
-\begin{mplibcode}[alt=testing]
+\begin{mplibcode}
 message "Hello World!";
 verbatimtex \moveright 0.4\hsize etex
 beginfig(0);
@@ -100,13 +103,13 @@ fill p withcolor transparent("normal", 0.5, red);
 fill p rotated 120 withcolor transparent("normal", 0.5, green);
 fill p rotated 240 withcolor transparent("normal", 0.5, blue);
 endfig;
-verbatimtex \leavevmode etex
+verbatimtex \mplibalttext{MetaPost}\leavevmode etex
 picture p; p := btex MetaPost etex scaled 2;
 beginfig(1);
 linear_shade(bbox p,0,blue,.7white);
 draw p withcolor white;
 endfig;
-verbatimtex \kern10pt etex
+verbatimtex \mplibalttext{MetaPost}\kern10pt etex
 beginfig(2);
 circular_shade(bbox p,0,blue,.7white);
 draw p withcolor white;
@@ -133,14 +136,14 @@ endfig;
 
 \mplibnoforcehmode
 \mplibnumbersystem{double}%
-\begin{mplibcode}[alt=testing]
+\begin{mplibcode}
 beginfig(0);
 u := 10**5*(10**-4);
 draw unitsquare scaled u;
 endfig;
 \end{mplibcode}%
 \mplibsetformat{plain}%
-\begin{mplibcode}[alt=testing]
+\begin{mplibcode}
   input graph;
   beginfig(0);
   draw begingraph(100,100);
@@ -159,7 +162,7 @@ dotlabel.rt("$\sqrt2$",origin);
 endfig;
 \end{mplibcode}%
 \leavevmode
-\begin{mplibcode}[alt=testing]
+\begin{mplibcode}
    D := sqrt(2)**7;
    beginfig(0);
    draw fullcircle scaled D;
@@ -188,7 +191,7 @@ endfig;
 \end{mplibcode}%
 
 %\mplibsetformat{metafun}%
-\begin{mplibcode}[alt=testing]
+\begin{mplibcode}
 beginfig(1)
 fill unitsquare xscaled \mpdim\textwidth yscaled 1cm
     withshadingmethod "linear"
@@ -205,7 +208,7 @@ fill unitsquare xscaled \mpdim\textwidth yscaled 1cm
 endfig;
 \end{mplibcode}%
 \leavevmode
-\mpfig[actualtext=Que]
+\mpfig[alt=Que]
 color yellow; yellow = (1,1,0);
 picture Q, u, e;
 Q := mplibglyph "Q" of "texgyrepagella-bolditalic.otf" scaled .1;
@@ -227,7 +230,7 @@ endfor
 \endmpfig
 \everymplib[@mpfig]{ drawoptions(withcolor mplibrgbtexcolor "olive"); }%
 \mpfig* input boxes \endmpfig
-\mpfig[alt=testing] circleit.a(btex\tracingcommands0 Box 1 etex); drawboxed(a); \endmpfig
+\mpfig circleit.a(btex\tracingcommands0 Box 1 etex); drawboxed(a); \endmpfig
 \def\mpfiginstancename{mympfig}%
 \mpfig[actualtext=$1/(1-x^2)$]
 draw mpliboutlinetext.b ("$\displaystyle\frac{1}{1-x^2}$")
@@ -236,7 +239,7 @@ draw mpliboutlinetext.b ("$\displaystyle\frac{1}{1-x^2}$")
     scaled 4 ;
 \endmpfig
 
-\mpfig[actualtext=Question]
+\mpfig[alt=Question]
   draw mpliboutlinetext.r
     ("Question")
     ( withpen pencircle scaled .3 )
@@ -259,7 +262,7 @@ draw (origin--right+up) scaled 5 withcolor 1/3[blue,white] ;
 draw (up--right) scaled 5 withcolor 1/3[red,white] ;
 \endmpfig
 \endmppattern
-\mpfig[alt=testing]
+\mpfig
 draw unitsquare shifted -center unitsquare scaled 45 withpostscript "collect" ;
 filldraw fullcircle scaled 100 withmppattern "mypatt" withpen pencircle scaled 1
   withcolor \mpcolor{red!50!blue!50} withpostscript "evenodd" ;
@@ -269,9 +272,10 @@ filldraw fullcircle scaled 100 withmppattern "mypatt" withpen pencircle scaled 1
     colored = false,
     matrix = "slanted .3 rotated 30",
   ]
+  \SuspendTagging{}%
   \tiny\TeX
 \end{mppattern}\relax
-\mpfig[actualtext=TeX]
+\mpfig[alt=TeX]
   picture tex;
   tex = mpliboutlinetext.p ("\bfseries \TeX");
   for i=1 upto mpliboutlinenum:
@@ -295,7 +299,7 @@ filldraw fullcircle scaled 100 withmppattern "mypatt" withpen pencircle scaled 1
 \endmpfig
 
 \leavevmode
-\mpfig[alt=testing]
+\mpfig
   picture mill; mill = btex \includegraphics[width=100bp]{mill} etex;
   draw mill;
   mill := mill shifted 125right;
@@ -308,7 +312,7 @@ filldraw fullcircle scaled 100 withmppattern "mypatt" withpen pencircle scaled 1
 \endmpfig
 
 \def\test#1{%
-  \mpfig[alt=testing]
+  \mpfig
   fill unitsquare shifted -center unitsquare scaled 200
     withshadingmethod "linear"
     withshadingcolors (.3[red,white], .3[blue,white])
@@ -335,11 +339,13 @@ filldraw fullcircle scaled 100 withmppattern "mypatt" withpen pencircle scaled 1
 \hbox{\test{knockout}\,\test{}}%
 \hbox to\MPwidth{\hss knockout\hss}%
 \leavevmode
-\mpfig[alt=testing] usemplibgroup "test:isolated,knockout" scaled 2/3 rotated 15 ; \endmpfig
-\usemplibgroup[alt=testing]{test:isolated,knockout}%
-\begin{mplibgroup}{mytex}[matrix="rotated 15"] \TeX \end{mplibgroup}%
+\mpfig usemplibgroup "test:isolated,knockout" scaled 2/3 rotated 15 ; \endmpfig
+\usemplibgroup{test:isolated,knockout}%
+\begin{mplibgroup}{mytex}[matrix="rotated 15"] \SuspendTagging{}\TeX \end{mplibgroup}%
+\tagmcbegin{artifact}%
 \hbox to0pt{\hss\vrule width.5pt height5pt depth5pt\hss}%
 \hbox to0pt{\hss\vrule width10pt height.25pt depth.25pt\hss}%
+\tagmcend
 \usemplibgroup[actualtext=TeX]{mytex}%
 \mpfig[actualtext=TeX] usemplibgroup "mytex"; draw (left--right) scaled 5; draw (up--down) scaled 5; \endmpfig
 
@@ -393,7 +399,7 @@ filldraw fullcircle scaled 100 withmppattern "mypatt" withpen pencircle scaled 1
     ;
   \endmpfig
 \endmppattern
-\mpfig[alt=testing]
+\mpfig[alt=testing nested pattern]
   fill fullcircle scaled 108
   withmppattern "p3"
   ;
@@ -428,7 +434,7 @@ endfig;
 \end{mplibcode}%
 Current instance name is: \currentmpinstancename \vskip 2\baselineskip
 
-\begin{mplibcode}[alt=testing]
+\begin{mplibcode}
 beginfig(1);
 if not known a:
   draw btex code is not inherited if instance name is not listed etex;
@@ -440,7 +446,7 @@ endfig;
 \end{mplibcode}%
 Current instance name is: \currentmpinstancename (should be empty) \vskip 2\baselineskip
 
-\begin{mplibcode}[alt=testing]
+\begin{mplibcode}
 beginfig(1);
 if not known a:
   draw btex code is not inherited if mplibcodeinherit is disabled and instance name is not explicitly set etex;

--- a/test-luamplib-latex.tex
+++ b/test-luamplib-latex.tex
@@ -14,6 +14,7 @@
 \everyendmplib{ endfig; }
 \mpliblegacybehavior{true}%
 \begin{document}
+\title{testing LuaMPlib}
 \mplibalttext{testing}
 \tracingcommands1
 A%

--- a/test-luamplib-plain.tex
+++ b/test-luamplib-plain.tex
@@ -171,10 +171,9 @@ draw mplibgraphictext "\bf Funny$\sqrt{2}$"
   fakebold 2 % fontspec option
   drawcolor blue fillcolor .5[red,white]
   scaled 3 rotated 30 ;
-picture p;
-p:=mplibgraphictext "\it xyz"
-  fillcolor .7white;
-draw p scaled 3 shifted (40,0);
+draw mplibgraphictext "\it xyz"
+  fillcolor .7white
+  scaled 3 shifted (40,0);
 endfig;
 \endmplibcode
 \par
@@ -315,9 +314,9 @@ usemplibgroup "testTRgroup"
 \mpfig usemplibgroup "mytex"; draw (left--right) scaled 5; draw (up--down) scaled 5; \endmpfig
 \par
 \mpfig
-  picture test; test = mplibgraphictext "\bf MPLIB"
-  fakebold 1 fillcolor .7[white,blue] drawcolor .7blue scaled 7;
-  draw test withmppattern "pattuncolored" ;
+  draw mplibgraphictext "\bf MPLIB"
+  fakebold 1 fillcolor .7[white,blue] drawcolor .7blue scaled 7
+  withmppattern "pattuncolored" ;
 \endmpfig
 \leavevmode
 \mpfig


### PR DESCRIPTION
* Changes regarding tagged PDF
  - `debug` key is removed
  - `correct-BBox` key is renamed to 'adjust-BBox'
  - `off` and `tagging-setup` keys are newly introduced
  - `actualtext` and `text` keys do not force horizontal mode
  - text box starting with `[taggingoff]` will not be tagged

* Other changes
  - more robust `mplibgraphictext` macro
  - hence, some examples in the documentation changed